### PR TITLE
refactor: avoid using unsafe code where possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concrete-fft"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["sarah el kazdadi <sarah.elkazdadi@zama.ai>"]
 description = "Concrete-FFT is a pure Rust high performance fast Fourier transform library."
@@ -11,19 +11,21 @@ homepage = "https://zama.ai/"
 keywords = ["fft"]
 
 [dependencies]
-num-complex = "0.4"
-dyn-stack = { version = "0.8", default-features = false }
 aligned-vec = { version = "0.5", default-features = false }
+bytemuck = "1"
+dyn-stack = { version = "0.9", default-features = false }
+num-complex = { version = "0.4", features = ["bytemuck"] }
+pulp = { version = "0.11", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 
 [features]
 default = ["std"]
-nightly = []
-std = []
+nightly = ["pulp/nightly"]
+std = ["pulp/std"]
 serde = ["dep:serde", "num-complex/serde"]
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 rustfft = "6.0"
 fftw-sys = { version = "0.6", default-features = false, features = ["system"] }
 rand = "0.8"
@@ -36,3 +38,6 @@ harness = false
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--html-in-header", "katex-header.html", "--cfg", "docsrs"]
+
+[profile.dev]
+lto = "off"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause Clear License
 
-Copyright © 2022 ZAMA.
+Copyright © 2023 ZAMA.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -16,7 +16,7 @@ materials provided with the distribution.
 3. Neither the name of ZAMA nor the names of its contributors may be used to endorse
 or promote products derived from this software without specific prior written permission.
 
-NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS LICENSE*.
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS LICENSE.
 THIS SOFTWARE IS PROVIDED BY THE ZAMA AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
 IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -26,8 +26,3 @@ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CA
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-*In addition to the rights carried by this license, ZAMA grants to the user a non-exclusive,
-free and non-commercial license on all patents filed in its name relating to the open-source
-code (the "Patents") for the sole purpose of evaluation, development, research, prototyping
-and experimentation.

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ This library provides two FFT modules:
 ```rust
 use concrete_fft::c64;
 use concrete_fft::ordered::{Plan, Method};
-use dyn_stack::{DynStack, GlobalMemBuffer, ReborrowMut};
+use dyn_stack::{PodStack, GlobalPodBuffer, ReborrowMut};
 use num_complex::ComplexFloat;
 use std::time::Duration;
 
 const N: usize = 4;
 let plan = Plan::new(4, Method::Measure(Duration::from_millis(10)));
-let mut scratch_memory = GlobalMemBuffer::new(plan.fft_scratch().unwrap());
-let mut stack = DynStack::new(&mut scratch_memory);
+let mut scratch_memory = GlobalPodBuffer::new(plan.fft_scratch().unwrap());
+let mut stack = PodStack::new(&mut scratch_memory);
 
 let data = [
     c64::new(1.0, 0.0),

--- a/benches/fft.rs
+++ b/benches/fft.rs
@@ -1,7 +1,7 @@
 use concrete_fft::c64;
 use core::ptr::NonNull;
 use criterion::{criterion_group, criterion_main, Criterion};
-use dyn_stack::{DynStack, ReborrowMut, StackReq};
+use dyn_stack::{PodStack, ReborrowMut, StackReq};
 
 struct FftwAlloc {
     bytes: NonNull<core::ffi::c_void>,
@@ -100,89 +100,61 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         1 << 15,
         1 << 16,
     ] {
-        let mut mem = dyn_stack::GlobalMemBuffer::new(
-            StackReq::new_aligned::<c64>(n, 64) // scratch
-                .and(
-                    StackReq::new_aligned::<c64>(2 * n, 64).or(StackReq::new_aligned::<c64>(n, 64)), // src | twiddles
-                )
-                .and(StackReq::new_aligned::<c64>(n, 64)), // dst
-        );
-        let mut stack = DynStack::new(&mut mem);
+        let mut mem = dyn_stack::GlobalPodBuffer::new(StackReq::all_of([
+            StackReq::new_aligned::<c64>(2 * n, 256), // scratch
+            StackReq::new_aligned::<c64>(n, 256),     // src
+            StackReq::new_aligned::<c64>(n, 256),     // dst
+        ]));
+        let mut stack = PodStack::new(&mut mem);
         let z = c64::new(0.0, 0.0);
 
-        {
-            use rustfft::FftPlannerAvx;
+        use rustfft::FftPlannerAvx;
+        let mut scratch = [];
+
+        let bench_duration = std::time::Duration::from_millis(10);
+        let unordered = concrete_fft::unordered::Plan::new(
+            n,
+            concrete_fft::unordered::Method::Measure(bench_duration),
+        );
+
+        let (mut dst, stack) = stack.rb_mut().make_aligned_with::<c64, _>(n, 64, |_| z);
+        let (mut src, mut stack) = stack.make_aligned_with::<c64, _>(n, 64, |_| z);
+
+        c.bench_function(&format!("rustfft-fwd-{}", n), |b| {
             let mut planner = FftPlannerAvx::<f64>::new().unwrap();
-
             let fwd_rustfft = planner.plan_fft_forward(n);
-            let mut scratch = [];
+            b.iter(|| fwd_rustfft.process_outofplace_with_scratch(&mut src, &mut dst, &mut scratch))
+        });
 
+        c.bench_function(&format!("fftw-fwd-{}", n), |b| {
             let fwd_fftw = PlanInterleavedC64::new(n, Sign::Forward);
-
-            let bench_duration = std::time::Duration::from_millis(10);
+            b.iter(|| {
+                fwd_fftw.execute(&mut src, &mut dst);
+            })
+        });
+        if n <= 1024 {
             let ordered = concrete_fft::ordered::Plan::new(
                 n,
                 concrete_fft::ordered::Method::Measure(bench_duration),
             );
-            let unordered = concrete_fft::unordered::Plan::new(
-                n,
-                concrete_fft::unordered::Method::Measure(bench_duration),
-            );
 
-            {
-                let (mut dst, stack) = stack.rb_mut().make_aligned_with::<c64, _>(n, 64, |_| z);
-                let (mut src, _) = stack.make_aligned_with::<c64, _>(n, 64, |_| z);
-
-                c.bench_function(&format!("rustfft-fwd-{}", n), |b| {
-                    b.iter(|| {
-                        fwd_rustfft.process_outofplace_with_scratch(
-                            &mut src,
-                            &mut dst,
-                            &mut scratch,
-                        )
-                    })
-                });
-
-                c.bench_function(&format!("fftw-fwd-{}", n), |b| {
-                    b.iter(|| {
-                        fwd_fftw.execute(&mut src, &mut dst);
-                    })
-                });
-            }
-            {
-                let (mut dst, mut stack) = stack.rb_mut().make_aligned_with::<c64, _>(n, 64, |_| z);
-
-                c.bench_function(&format!("concrete-fwd-{}", n), |b| {
-                    b.iter(|| ordered.fwd(&mut *dst, stack.rb_mut()))
-                });
-            }
-            {
-                let (mut dst, mut stack) = stack.rb_mut().make_aligned_with::<c64, _>(n, 64, |_| z);
-
-                c.bench_function(&format!("unordered-fwd-{}", n), |b| {
-                    b.iter(|| unordered.fwd(&mut dst, stack.rb_mut()));
-                });
-            }
-            {
-                let (mut dst, mut stack) = stack.rb_mut().make_aligned_with::<c64, _>(n, 64, |_| z);
-
-                c.bench_function(&format!("unordered-inv-{}", n), |b| {
-                    b.iter(|| unordered.inv(&mut dst, stack.rb_mut()));
-                });
-            }
-        }
-
-        // memcpy
-        {
-            let (mut dst, stack) = stack.rb_mut().make_aligned_with::<c64, _>(n, 64, |_| z);
-            let (src, _) = stack.make_aligned_with::<c64, _>(n, 64, |_| z);
-
-            c.bench_function(&format!("memcpy-{}", n), |b| {
-                b.iter(|| unsafe {
-                    std::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), n);
-                })
+            c.bench_function(&format!("concrete-fwd-{}", n), |b| {
+                b.iter(|| ordered.fwd(&mut dst, stack.rb_mut()))
             });
         }
+        c.bench_function(&format!("unordered-fwd-{}", n), |b| {
+            b.iter(|| unordered.fwd(&mut dst, stack.rb_mut()));
+        });
+        c.bench_function(&format!("unordered-inv-{}", n), |b| {
+            b.iter(|| unordered.inv(&mut dst, stack.rb_mut()));
+        });
+
+        // memcpy
+        c.bench_function(&format!("memcpy-{}", n), |b| {
+            b.iter(|| unsafe {
+                std::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), n);
+            })
+        });
     }
 }
 

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,3 +1,0 @@
-#![allow(dead_code)]
-
-mod fft;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+unstable_features = true
+imports_granularity="crate"
+format_code_in_doc_comments = true
+wrap_comments = true
+comment_width = 100

--- a/src/dif16.rs
+++ b/src/dif16.rs
@@ -1,1024 +1,966 @@
-// Copyright (c) 2019 OK Ojisan(Takuya OKAHISA)
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy of
-// this software and associated documentation files (the "Software"), to deal in
-// the Software without restriction, including without limitation the rights to
-// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-// of the Software, and to permit persons to whom the Software is furnished to do
-// so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
-use crate::c64;
-use crate::dif2::end_2;
-use crate::dif4::end_4;
-use crate::dif8::end_8;
-use crate::fft_simd::{twid, twid_t, FftSimd64, FftSimd64Ext, FftSimd64X2, FftSimd64X4, Scalar};
-use crate::x86_feature_detected;
+use crate::{
+    c64,
+    dif2::{split_2, split_mut_2},
+    dif8::{split_8, split_mut_8},
+    fft_simd::{FftSimd, FftSimdExt, Pod},
+    fn_ptr, nat, RecursiveFft,
+};
 
 #[inline(always)]
-unsafe fn core_<I: FftSimd64>(
-    fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
+pub fn split_16<T>(
+    slice: &[T],
+) -> (
+    &[T],
+    &[T],
+    &[T],
+    &[T],
+    &[T],
+    &[T],
+    &[T],
+    &[T],
+    &[T],
+    &[T],
+    &[T],
+    &[T],
+    &[T],
+    &[T],
+    &[T],
+    &[T],
 ) {
-    debug_assert_eq!(s % I::COMPLEX_PER_REG, 0);
-
-    let m = n / 16;
-    let big_n = n * s;
-    let big_n0 = 0;
-    let big_n1 = big_n / 16;
-    let big_n2 = big_n1 * 2;
-    let big_n3 = big_n1 * 3;
-    let big_n4 = big_n1 * 4;
-    let big_n5 = big_n1 * 5;
-    let big_n6 = big_n1 * 6;
-    let big_n7 = big_n1 * 7;
-    let big_n8 = big_n1 * 8;
-    let big_n9 = big_n1 * 9;
-    let big_na = big_n1 * 10;
-    let big_nb = big_n1 * 11;
-    let big_nc = big_n1 * 12;
-    let big_nd = big_n1 * 13;
-    let big_ne = big_n1 * 14;
-    let big_nf = big_n1 * 15;
-
-    for p in 0..m {
-        let sp = s * p;
-        let s16p = 16 * sp;
-
-        let w1p = I::splat(twid_t(16, big_n, 0x1, w, sp));
-        let w2p = I::splat(twid_t(16, big_n, 0x2, w, sp));
-        let w3p = I::splat(twid_t(16, big_n, 0x3, w, sp));
-        let w4p = I::splat(twid_t(16, big_n, 0x4, w, sp));
-        let w5p = I::splat(twid_t(16, big_n, 0x5, w, sp));
-        let w6p = I::splat(twid_t(16, big_n, 0x6, w, sp));
-        let w7p = I::splat(twid_t(16, big_n, 0x7, w, sp));
-        let w8p = I::splat(twid_t(16, big_n, 0x8, w, sp));
-        let w9p = I::splat(twid_t(16, big_n, 0x9, w, sp));
-        let wap = I::splat(twid_t(16, big_n, 0xa, w, sp));
-        let wbp = I::splat(twid_t(16, big_n, 0xb, w, sp));
-        let wcp = I::splat(twid_t(16, big_n, 0xc, w, sp));
-        let wdp = I::splat(twid_t(16, big_n, 0xd, w, sp));
-        let wep = I::splat(twid_t(16, big_n, 0xe, w, sp));
-        let wfp = I::splat(twid_t(16, big_n, 0xf, w, sp));
-
-        let mut q = 0;
-        while q < s {
-            let xq_sp = x.add(q + sp);
-            let yq_s16p = y.add(q + s16p);
-
-            let x0 = I::load(xq_sp.add(big_n0));
-            let x1 = I::load(xq_sp.add(big_n1));
-            let x2 = I::load(xq_sp.add(big_n2));
-            let x3 = I::load(xq_sp.add(big_n3));
-            let x4 = I::load(xq_sp.add(big_n4));
-            let x5 = I::load(xq_sp.add(big_n5));
-            let x6 = I::load(xq_sp.add(big_n6));
-            let x7 = I::load(xq_sp.add(big_n7));
-            let x8 = I::load(xq_sp.add(big_n8));
-            let x9 = I::load(xq_sp.add(big_n9));
-            let xa = I::load(xq_sp.add(big_na));
-            let xb = I::load(xq_sp.add(big_nb));
-            let xc = I::load(xq_sp.add(big_nc));
-            let xd = I::load(xq_sp.add(big_nd));
-            let xe = I::load(xq_sp.add(big_ne));
-            let xf = I::load(xq_sp.add(big_nf));
-
-            let a08 = I::add(x0, x8);
-            let s08 = I::sub(x0, x8);
-            let a4c = I::add(x4, xc);
-            let s4c = I::sub(x4, xc);
-            let a2a = I::add(x2, xa);
-            let s2a = I::sub(x2, xa);
-            let a6e = I::add(x6, xe);
-            let s6e = I::sub(x6, xe);
-            let a19 = I::add(x1, x9);
-            let s19 = I::sub(x1, x9);
-            let a5d = I::add(x5, xd);
-            let s5d = I::sub(x5, xd);
-            let a3b = I::add(x3, xb);
-            let s3b = I::sub(x3, xb);
-            let a7f = I::add(x7, xf);
-            let s7f = I::sub(x7, xf);
-
-            let js4c = I::xpj(fwd, s4c);
-            let js6e = I::xpj(fwd, s6e);
-            let js5d = I::xpj(fwd, s5d);
-            let js7f = I::xpj(fwd, s7f);
-
-            let a08p1a4c = I::add(a08, a4c);
-            let s08mjs4c = I::sub(s08, js4c);
-            let a08m1a4c = I::sub(a08, a4c);
-            let s08pjs4c = I::add(s08, js4c);
-            let a2ap1a6e = I::add(a2a, a6e);
-            let s2amjs6e = I::sub(s2a, js6e);
-            let a2am1a6e = I::sub(a2a, a6e);
-            let s2apjs6e = I::add(s2a, js6e);
-            let a19p1a5d = I::add(a19, a5d);
-            let s19mjs5d = I::sub(s19, js5d);
-            let a19m1a5d = I::sub(a19, a5d);
-            let s19pjs5d = I::add(s19, js5d);
-            let a3bp1a7f = I::add(a3b, a7f);
-            let s3bmjs7f = I::sub(s3b, js7f);
-            let a3bm1a7f = I::sub(a3b, a7f);
-            let s3bpjs7f = I::add(s3b, js7f);
-
-            let w8_s2amjs6e = I::xw8(fwd, s2amjs6e);
-            let j_a2am1a6e = I::xpj(fwd, a2am1a6e);
-            let v8_s2apjs6e = I::xv8(fwd, s2apjs6e);
-
-            let a08p1a4c_p1_a2ap1a6e = I::add(a08p1a4c, a2ap1a6e);
-            let s08mjs4c_pw_s2amjs6e = I::add(s08mjs4c, w8_s2amjs6e);
-            let a08m1a4c_mj_a2am1a6e = I::sub(a08m1a4c, j_a2am1a6e);
-            let s08pjs4c_mv_s2apjs6e = I::sub(s08pjs4c, v8_s2apjs6e);
-            let a08p1a4c_m1_a2ap1a6e = I::sub(a08p1a4c, a2ap1a6e);
-            let s08mjs4c_mw_s2amjs6e = I::sub(s08mjs4c, w8_s2amjs6e);
-            let a08m1a4c_pj_a2am1a6e = I::add(a08m1a4c, j_a2am1a6e);
-            let s08pjs4c_pv_s2apjs6e = I::add(s08pjs4c, v8_s2apjs6e);
-
-            let w8_s3bmjs7f = I::xw8(fwd, s3bmjs7f);
-            let j_a3bm1a7f = I::xpj(fwd, a3bm1a7f);
-            let v8_s3bpjs7f = I::xv8(fwd, s3bpjs7f);
-
-            let a19p1a5d_p1_a3bp1a7f = I::add(a19p1a5d, a3bp1a7f);
-            let s19mjs5d_pw_s3bmjs7f = I::add(s19mjs5d, w8_s3bmjs7f);
-            let a19m1a5d_mj_a3bm1a7f = I::sub(a19m1a5d, j_a3bm1a7f);
-            let s19pjs5d_mv_s3bpjs7f = I::sub(s19pjs5d, v8_s3bpjs7f);
-            let a19p1a5d_m1_a3bp1a7f = I::sub(a19p1a5d, a3bp1a7f);
-            let s19mjs5d_mw_s3bmjs7f = I::sub(s19mjs5d, w8_s3bmjs7f);
-            let a19m1a5d_pj_a3bm1a7f = I::add(a19m1a5d, j_a3bm1a7f);
-            let s19pjs5d_pv_s3bpjs7f = I::add(s19pjs5d, v8_s3bpjs7f);
-
-            let h1_s19mjs5d_pw_s3bmjs7f = I::xh1(fwd, s19mjs5d_pw_s3bmjs7f);
-            let w8_a19m1a5d_mj_a3bm1a7f = I::xw8(fwd, a19m1a5d_mj_a3bm1a7f);
-            let h3_s19pjs5d_mv_s3bpjs7f = I::xh3(fwd, s19pjs5d_mv_s3bpjs7f);
-            let j_a19p1a5d_m1_a3bp1a7f = I::xpj(fwd, a19p1a5d_m1_a3bp1a7f);
-            let hd_s19mjs5d_mw_s3bmjs7f = I::xhd(fwd, s19mjs5d_mw_s3bmjs7f);
-            let v8_a19m1a5d_pj_a3bm1a7f = I::xv8(fwd, a19m1a5d_pj_a3bm1a7f);
-            let hf_s19pjs5d_pv_s3bpjs7f = I::xhf(fwd, s19pjs5d_pv_s3bpjs7f);
-
-            I::store(
-                yq_s16p.add(0),
-                I::add(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f),
-            );
-            I::store(
-                yq_s16p.add(s),
-                I::mul(w1p, I::add(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0x2),
-                I::mul(w2p, I::add(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0x3),
-                I::mul(w3p, I::add(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0x4),
-                I::mul(w4p, I::sub(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0x5),
-                I::mul(w5p, I::sub(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0x6),
-                I::mul(w6p, I::sub(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0x7),
-                I::mul(w7p, I::sub(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f)),
-            );
-
-            I::store(
-                yq_s16p.add(s * 0x8),
-                I::mul(w8p, I::sub(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0x9),
-                I::mul(w9p, I::sub(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0xa),
-                I::mul(wap, I::sub(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0xb),
-                I::mul(wbp, I::sub(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0xc),
-                I::mul(wcp, I::add(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0xd),
-                I::mul(wdp, I::add(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0xe),
-                I::mul(wep, I::add(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f)),
-            );
-            I::store(
-                yq_s16p.add(s * 0xf),
-                I::mul(wfp, I::add(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f)),
-            );
-
-            q += I::COMPLEX_PER_REG;
-        }
-    }
-}
-
-#[inline(always)]
-#[allow(dead_code)]
-unsafe fn core_x2<I: FftSimd64X2>(
-    fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
-) {
-    debug_assert_eq!(s, 1);
-
-    let big_n = n;
-    let big_n0 = 0;
-    let big_n1 = big_n / 16;
-    let big_n2 = big_n1 * 2;
-    let big_n3 = big_n1 * 3;
-    let big_n4 = big_n1 * 4;
-    let big_n5 = big_n1 * 5;
-    let big_n6 = big_n1 * 6;
-    let big_n7 = big_n1 * 7;
-    let big_n8 = big_n1 * 8;
-    let big_n9 = big_n1 * 9;
-    let big_na = big_n1 * 10;
-    let big_nb = big_n1 * 11;
-    let big_nc = big_n1 * 12;
-    let big_nd = big_n1 * 13;
-    let big_ne = big_n1 * 14;
-    let big_nf = big_n1 * 15;
-
-    let mut p = 0;
-    while p < big_n1 {
-        let x_p = x.add(p);
-        let y_16p = y.add(16 * p);
-
-        let x0 = I::load(x_p.add(big_n0));
-        let x1 = I::load(x_p.add(big_n1));
-        let x2 = I::load(x_p.add(big_n2));
-        let x3 = I::load(x_p.add(big_n3));
-        let x4 = I::load(x_p.add(big_n4));
-        let x5 = I::load(x_p.add(big_n5));
-        let x6 = I::load(x_p.add(big_n6));
-        let x7 = I::load(x_p.add(big_n7));
-        let x8 = I::load(x_p.add(big_n8));
-        let x9 = I::load(x_p.add(big_n9));
-        let xa = I::load(x_p.add(big_na));
-        let xb = I::load(x_p.add(big_nb));
-        let xc = I::load(x_p.add(big_nc));
-        let xd = I::load(x_p.add(big_nd));
-        let xe = I::load(x_p.add(big_ne));
-        let xf = I::load(x_p.add(big_nf));
-
-        let a08 = I::add(x0, x8);
-        let s08 = I::sub(x0, x8);
-        let a4c = I::add(x4, xc);
-        let s4c = I::sub(x4, xc);
-        let a2a = I::add(x2, xa);
-        let s2a = I::sub(x2, xa);
-        let a6e = I::add(x6, xe);
-        let s6e = I::sub(x6, xe);
-        let a19 = I::add(x1, x9);
-        let s19 = I::sub(x1, x9);
-        let a5d = I::add(x5, xd);
-        let s5d = I::sub(x5, xd);
-        let a3b = I::add(x3, xb);
-        let s3b = I::sub(x3, xb);
-        let a7f = I::add(x7, xf);
-        let s7f = I::sub(x7, xf);
-
-        let js4c = I::xpj(fwd, s4c);
-        let js6e = I::xpj(fwd, s6e);
-        let js5d = I::xpj(fwd, s5d);
-        let js7f = I::xpj(fwd, s7f);
-
-        let a08p1a4c = I::add(a08, a4c);
-        let s08mjs4c = I::sub(s08, js4c);
-        let a08m1a4c = I::sub(a08, a4c);
-        let s08pjs4c = I::add(s08, js4c);
-        let a2ap1a6e = I::add(a2a, a6e);
-        let s2amjs6e = I::sub(s2a, js6e);
-        let a2am1a6e = I::sub(a2a, a6e);
-        let s2apjs6e = I::add(s2a, js6e);
-        let a19p1a5d = I::add(a19, a5d);
-        let s19mjs5d = I::sub(s19, js5d);
-        let a19m1a5d = I::sub(a19, a5d);
-        let s19pjs5d = I::add(s19, js5d);
-        let a3bp1a7f = I::add(a3b, a7f);
-        let s3bmjs7f = I::sub(s3b, js7f);
-        let a3bm1a7f = I::sub(a3b, a7f);
-        let s3bpjs7f = I::add(s3b, js7f);
-
-        let w8_s2amjs6e = I::xw8(fwd, s2amjs6e);
-        let j_a2am1a6e = I::xpj(fwd, a2am1a6e);
-        let v8_s2apjs6e = I::xv8(fwd, s2apjs6e);
-
-        let a08p1a4c_p1_a2ap1a6e = I::add(a08p1a4c, a2ap1a6e);
-        let s08mjs4c_pw_s2amjs6e = I::add(s08mjs4c, w8_s2amjs6e);
-        let a08m1a4c_mj_a2am1a6e = I::sub(a08m1a4c, j_a2am1a6e);
-        let s08pjs4c_mv_s2apjs6e = I::sub(s08pjs4c, v8_s2apjs6e);
-        let a08p1a4c_m1_a2ap1a6e = I::sub(a08p1a4c, a2ap1a6e);
-        let s08mjs4c_mw_s2amjs6e = I::sub(s08mjs4c, w8_s2amjs6e);
-        let a08m1a4c_pj_a2am1a6e = I::add(a08m1a4c, j_a2am1a6e);
-        let s08pjs4c_pv_s2apjs6e = I::add(s08pjs4c, v8_s2apjs6e);
-
-        let w8_s3bmjs7f = I::xw8(fwd, s3bmjs7f);
-        let j_a3bm1a7f = I::xpj(fwd, a3bm1a7f);
-        let v8_s3bpjs7f = I::xv8(fwd, s3bpjs7f);
-
-        let a19p1a5d_p1_a3bp1a7f = I::add(a19p1a5d, a3bp1a7f);
-        let s19mjs5d_pw_s3bmjs7f = I::add(s19mjs5d, w8_s3bmjs7f);
-        let a19m1a5d_mj_a3bm1a7f = I::sub(a19m1a5d, j_a3bm1a7f);
-        let s19pjs5d_mv_s3bpjs7f = I::sub(s19pjs5d, v8_s3bpjs7f);
-        let a19p1a5d_m1_a3bp1a7f = I::sub(a19p1a5d, a3bp1a7f);
-        let s19mjs5d_mw_s3bmjs7f = I::sub(s19mjs5d, w8_s3bmjs7f);
-        let a19m1a5d_pj_a3bm1a7f = I::add(a19m1a5d, j_a3bm1a7f);
-        let s19pjs5d_pv_s3bpjs7f = I::add(s19pjs5d, v8_s3bpjs7f);
-
-        let h1_s19mjs5d_pw_s3bmjs7f = I::xh1(fwd, s19mjs5d_pw_s3bmjs7f);
-        let w8_a19m1a5d_mj_a3bm1a7f = I::xw8(fwd, a19m1a5d_mj_a3bm1a7f);
-        let h3_s19pjs5d_mv_s3bpjs7f = I::xh3(fwd, s19pjs5d_mv_s3bpjs7f);
-        let j_a19p1a5d_m1_a3bp1a7f = I::xpj(fwd, a19p1a5d_m1_a3bp1a7f);
-        let hd_s19mjs5d_mw_s3bmjs7f = I::xhd(fwd, s19mjs5d_mw_s3bmjs7f);
-        let v8_a19m1a5d_pj_a3bm1a7f = I::xv8(fwd, a19m1a5d_pj_a3bm1a7f);
-        let hf_s19pjs5d_pv_s3bpjs7f = I::xhf(fwd, s19pjs5d_pv_s3bpjs7f);
-
-        let w1p = I::load(twid(16, big_n, 1, w, p));
-        let w2p = I::load(twid(16, big_n, 2, w, p));
-        let w3p = I::load(twid(16, big_n, 3, w, p));
-        let w4p = I::load(twid(16, big_n, 4, w, p));
-        let w5p = I::load(twid(16, big_n, 5, w, p));
-        let w6p = I::load(twid(16, big_n, 6, w, p));
-        let w7p = I::load(twid(16, big_n, 7, w, p));
-        let w8p = I::load(twid(16, big_n, 8, w, p));
-        let w9p = I::load(twid(16, big_n, 9, w, p));
-        let wap = I::load(twid(16, big_n, 10, w, p));
-        let wbp = I::load(twid(16, big_n, 11, w, p));
-        let wcp = I::load(twid(16, big_n, 12, w, p));
-        let wdp = I::load(twid(16, big_n, 13, w, p));
-        let wep = I::load(twid(16, big_n, 14, w, p));
-        let wfp = I::load(twid(16, big_n, 15, w, p));
-
-        let aa = I::add(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f);
-        let bb = I::mul(w1p, I::add(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f));
-        let cc = I::mul(w2p, I::add(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f));
-        let dd = I::mul(w3p, I::add(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f));
-        let ee = I::mul(w4p, I::sub(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f));
-        let ff = I::mul(w5p, I::sub(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f));
-        let gg = I::mul(w6p, I::sub(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f));
-        let hh = I::mul(w7p, I::sub(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f));
-
-        let ii = I::mul(w8p, I::sub(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f));
-        let jj = I::mul(w9p, I::sub(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f));
-        let kk = I::mul(wap, I::sub(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f));
-        let ll = I::mul(wbp, I::sub(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f));
-        let mm = I::mul(wcp, I::add(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f));
-        let nn = I::mul(wdp, I::add(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f));
-        let oo = I::mul(wep, I::add(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f));
-        let pp = I::mul(wfp, I::add(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f));
-
-        {
-            let ab = I::catlo(aa, bb);
-            I::store(y_16p.add(0x00), ab);
-            let cd = I::catlo(cc, dd);
-            I::store(y_16p.add(0x02), cd);
-            let ef = I::catlo(ee, ff);
-            I::store(y_16p.add(0x04), ef);
-            let gh = I::catlo(gg, hh);
-            I::store(y_16p.add(0x06), gh);
-            let ij = I::catlo(ii, jj);
-            I::store(y_16p.add(0x08), ij);
-            let kl = I::catlo(kk, ll);
-            I::store(y_16p.add(0x0a), kl);
-            let mn = I::catlo(mm, nn);
-            I::store(y_16p.add(0x0c), mn);
-            let op = I::catlo(oo, pp);
-            I::store(y_16p.add(0x0e), op);
-        }
-        {
-            let ab = I::cathi(aa, bb);
-            I::store(y_16p.add(0x10), ab);
-            let cd = I::cathi(cc, dd);
-            I::store(y_16p.add(0x12), cd);
-            let ef = I::cathi(ee, ff);
-            I::store(y_16p.add(0x14), ef);
-            let gh = I::cathi(gg, hh);
-            I::store(y_16p.add(0x16), gh);
-            let ij = I::cathi(ii, jj);
-            I::store(y_16p.add(0x18), ij);
-            let kl = I::cathi(kk, ll);
-            I::store(y_16p.add(0x1a), kl);
-            let mn = I::cathi(mm, nn);
-            I::store(y_16p.add(0x1c), mn);
-            let op = I::cathi(oo, pp);
-            I::store(y_16p.add(0x1e), op);
-        }
-
-        p += 2;
-    }
-}
-
-#[inline(always)]
-#[allow(dead_code)]
-unsafe fn core_x4<I2: FftSimd64X2, I4: FftSimd64X4>(
-    fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
-) {
-    debug_assert_eq!(s, 1);
-    if n == 32 {
-        return core_x2::<I2>(fwd, n, s, x, y, w);
-    }
-
-    let big_n = n;
-    let big_n0 = 0;
-    let big_n1 = big_n / 16;
-    let big_n2 = big_n1 * 2;
-    let big_n3 = big_n1 * 3;
-    let big_n4 = big_n1 * 4;
-    let big_n5 = big_n1 * 5;
-    let big_n6 = big_n1 * 6;
-    let big_n7 = big_n1 * 7;
-    let big_n8 = big_n1 * 8;
-    let big_n9 = big_n1 * 9;
-    let big_na = big_n1 * 10;
-    let big_nb = big_n1 * 11;
-    let big_nc = big_n1 * 12;
-    let big_nd = big_n1 * 13;
-    let big_ne = big_n1 * 14;
-    let big_nf = big_n1 * 15;
-
-    debug_assert_eq!(big_n1 % 4, 0);
-    let mut p = 0;
-    while p < big_n1 {
-        let x_p = x.add(p);
-        let y_16p = y.add(16 * p);
-
-        let x0 = I4::load(x_p.add(big_n0));
-        let x1 = I4::load(x_p.add(big_n1));
-        let x2 = I4::load(x_p.add(big_n2));
-        let x3 = I4::load(x_p.add(big_n3));
-        let x4 = I4::load(x_p.add(big_n4));
-        let x5 = I4::load(x_p.add(big_n5));
-        let x6 = I4::load(x_p.add(big_n6));
-        let x7 = I4::load(x_p.add(big_n7));
-        let x8 = I4::load(x_p.add(big_n8));
-        let x9 = I4::load(x_p.add(big_n9));
-        let xa = I4::load(x_p.add(big_na));
-        let xb = I4::load(x_p.add(big_nb));
-        let xc = I4::load(x_p.add(big_nc));
-        let xd = I4::load(x_p.add(big_nd));
-        let xe = I4::load(x_p.add(big_ne));
-        let xf = I4::load(x_p.add(big_nf));
-
-        let a08 = I4::add(x0, x8);
-        let s08 = I4::sub(x0, x8);
-        let a4c = I4::add(x4, xc);
-        let s4c = I4::sub(x4, xc);
-        let a2a = I4::add(x2, xa);
-        let s2a = I4::sub(x2, xa);
-        let a6e = I4::add(x6, xe);
-        let s6e = I4::sub(x6, xe);
-        let a19 = I4::add(x1, x9);
-        let s19 = I4::sub(x1, x9);
-        let a5d = I4::add(x5, xd);
-        let s5d = I4::sub(x5, xd);
-        let a3b = I4::add(x3, xb);
-        let s3b = I4::sub(x3, xb);
-        let a7f = I4::add(x7, xf);
-        let s7f = I4::sub(x7, xf);
-
-        let js4c = I4::xpj(fwd, s4c);
-        let js6e = I4::xpj(fwd, s6e);
-        let js5d = I4::xpj(fwd, s5d);
-        let js7f = I4::xpj(fwd, s7f);
-
-        let a08p1a4c = I4::add(a08, a4c);
-        let s08mjs4c = I4::sub(s08, js4c);
-        let a08m1a4c = I4::sub(a08, a4c);
-        let s08pjs4c = I4::add(s08, js4c);
-        let a2ap1a6e = I4::add(a2a, a6e);
-        let s2amjs6e = I4::sub(s2a, js6e);
-        let a2am1a6e = I4::sub(a2a, a6e);
-        let s2apjs6e = I4::add(s2a, js6e);
-        let a19p1a5d = I4::add(a19, a5d);
-        let s19mjs5d = I4::sub(s19, js5d);
-        let a19m1a5d = I4::sub(a19, a5d);
-        let s19pjs5d = I4::add(s19, js5d);
-        let a3bp1a7f = I4::add(a3b, a7f);
-        let s3bmjs7f = I4::sub(s3b, js7f);
-        let a3bm1a7f = I4::sub(a3b, a7f);
-        let s3bpjs7f = I4::add(s3b, js7f);
-
-        let w8_s2amjs6e = I4::xw8(fwd, s2amjs6e);
-        let j_a2am1a6e = I4::xpj(fwd, a2am1a6e);
-        let v8_s2apjs6e = I4::xv8(fwd, s2apjs6e);
-
-        let a08p1a4c_p1_a2ap1a6e = I4::add(a08p1a4c, a2ap1a6e);
-        let s08mjs4c_pw_s2amjs6e = I4::add(s08mjs4c, w8_s2amjs6e);
-        let a08m1a4c_mj_a2am1a6e = I4::sub(a08m1a4c, j_a2am1a6e);
-        let s08pjs4c_mv_s2apjs6e = I4::sub(s08pjs4c, v8_s2apjs6e);
-        let a08p1a4c_m1_a2ap1a6e = I4::sub(a08p1a4c, a2ap1a6e);
-        let s08mjs4c_mw_s2amjs6e = I4::sub(s08mjs4c, w8_s2amjs6e);
-        let a08m1a4c_pj_a2am1a6e = I4::add(a08m1a4c, j_a2am1a6e);
-        let s08pjs4c_pv_s2apjs6e = I4::add(s08pjs4c, v8_s2apjs6e);
-
-        let w8_s3bmjs7f = I4::xw8(fwd, s3bmjs7f);
-        let j_a3bm1a7f = I4::xpj(fwd, a3bm1a7f);
-        let v8_s3bpjs7f = I4::xv8(fwd, s3bpjs7f);
-
-        let a19p1a5d_p1_a3bp1a7f = I4::add(a19p1a5d, a3bp1a7f);
-        let s19mjs5d_pw_s3bmjs7f = I4::add(s19mjs5d, w8_s3bmjs7f);
-        let a19m1a5d_mj_a3bm1a7f = I4::sub(a19m1a5d, j_a3bm1a7f);
-        let s19pjs5d_mv_s3bpjs7f = I4::sub(s19pjs5d, v8_s3bpjs7f);
-        let a19p1a5d_m1_a3bp1a7f = I4::sub(a19p1a5d, a3bp1a7f);
-        let s19mjs5d_mw_s3bmjs7f = I4::sub(s19mjs5d, w8_s3bmjs7f);
-        let a19m1a5d_pj_a3bm1a7f = I4::add(a19m1a5d, j_a3bm1a7f);
-        let s19pjs5d_pv_s3bpjs7f = I4::add(s19pjs5d, v8_s3bpjs7f);
-
-        let h1_s19mjs5d_pw_s3bmjs7f = I4::xh1(fwd, s19mjs5d_pw_s3bmjs7f);
-        let w8_a19m1a5d_mj_a3bm1a7f = I4::xw8(fwd, a19m1a5d_mj_a3bm1a7f);
-        let h3_s19pjs5d_mv_s3bpjs7f = I4::xh3(fwd, s19pjs5d_mv_s3bpjs7f);
-        let j_a19p1a5d_m1_a3bp1a7f = I4::xpj(fwd, a19p1a5d_m1_a3bp1a7f);
-        let hd_s19mjs5d_mw_s3bmjs7f = I4::xhd(fwd, s19mjs5d_mw_s3bmjs7f);
-        let v8_a19m1a5d_pj_a3bm1a7f = I4::xv8(fwd, a19m1a5d_pj_a3bm1a7f);
-        let hf_s19pjs5d_pv_s3bpjs7f = I4::xhf(fwd, s19pjs5d_pv_s3bpjs7f);
-
-        let w1p = I4::load(twid(16, big_n, 1, w, p));
-        let w2p = I4::load(twid(16, big_n, 2, w, p));
-        let w3p = I4::load(twid(16, big_n, 3, w, p));
-        let w4p = I4::load(twid(16, big_n, 4, w, p));
-        let w5p = I4::load(twid(16, big_n, 5, w, p));
-        let w6p = I4::load(twid(16, big_n, 6, w, p));
-        let w7p = I4::load(twid(16, big_n, 7, w, p));
-        let w8p = I4::load(twid(16, big_n, 8, w, p));
-        let w9p = I4::load(twid(16, big_n, 9, w, p));
-        let wap = I4::load(twid(16, big_n, 10, w, p));
-        let wbp = I4::load(twid(16, big_n, 11, w, p));
-        let wcp = I4::load(twid(16, big_n, 12, w, p));
-        let wdp = I4::load(twid(16, big_n, 13, w, p));
-        let wep = I4::load(twid(16, big_n, 14, w, p));
-        let wfp = I4::load(twid(16, big_n, 15, w, p));
-
-        let a_ = I4::add(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f);
-        let b_ = I4::mul(w1p, I4::add(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f));
-        let c_ = I4::mul(w2p, I4::add(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f));
-        let d_ = I4::mul(w3p, I4::add(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f));
-        let e_ = I4::mul(w4p, I4::sub(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f));
-        let f_ = I4::mul(w5p, I4::sub(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f));
-        let g_ = I4::mul(w6p, I4::sub(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f));
-        let h_ = I4::mul(w7p, I4::sub(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f));
-
-        let i_ = I4::mul(w8p, I4::sub(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f));
-        let j_ = I4::mul(w9p, I4::sub(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f));
-        let k_ = I4::mul(wap, I4::sub(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f));
-        let l_ = I4::mul(wbp, I4::sub(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f));
-        let m_ = I4::mul(wcp, I4::add(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f));
-        let n_ = I4::mul(wdp, I4::add(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f));
-        let o_ = I4::mul(wep, I4::add(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f));
-        let p_ = I4::mul(wfp, I4::add(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f));
-
-        let (abcd0, abcd1, abcd2, abcd3) = I4::transpose(a_, b_, c_, d_);
-        let (efgh0, efgh1, efgh2, efgh3) = I4::transpose(e_, f_, g_, h_);
-        let (ijkl0, ijkl1, ijkl2, ijkl3) = I4::transpose(i_, j_, k_, l_);
-        let (mnop0, mnop1, mnop2, mnop3) = I4::transpose(m_, n_, o_, p_);
-
-        I4::store(y_16p.add(0x00), abcd0);
-        I4::store(y_16p.add(0x04), efgh0);
-        I4::store(y_16p.add(0x08), ijkl0);
-        I4::store(y_16p.add(0x0c), mnop0);
-
-        I4::store(y_16p.add(0x10), abcd1);
-        I4::store(y_16p.add(0x14), efgh1);
-        I4::store(y_16p.add(0x18), ijkl1);
-        I4::store(y_16p.add(0x1c), mnop1);
-
-        I4::store(y_16p.add(0x20), abcd2);
-        I4::store(y_16p.add(0x24), efgh2);
-        I4::store(y_16p.add(0x28), ijkl2);
-        I4::store(y_16p.add(0x2c), mnop2);
-
-        I4::store(y_16p.add(0x30), abcd3);
-        I4::store(y_16p.add(0x34), efgh3);
-        I4::store(y_16p.add(0x38), ijkl3);
-        I4::store(y_16p.add(0x3c), mnop3);
-
-        p += 4;
-    }
-}
-
-#[inline(always)]
-pub(crate) unsafe fn end16<I: FftSimd64>(
-    fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    eo: bool,
-) {
-    debug_assert_eq!(n, 16);
-    debug_assert_eq!(s % I::COMPLEX_PER_REG, 0);
-
-    let z = if eo { y } else { x };
-
-    let mut q = 0;
-    while q < s {
-        let xq = x.add(q);
-        let zq = z.add(q);
-
-        let x0 = I::load(xq.add(s * 0x0));
-        let x1 = I::load(xq.add(s * 0x1));
-        let x2 = I::load(xq.add(s * 0x2));
-        let x3 = I::load(xq.add(s * 0x3));
-        let x4 = I::load(xq.add(s * 0x4));
-        let x5 = I::load(xq.add(s * 0x5));
-        let x6 = I::load(xq.add(s * 0x6));
-        let x7 = I::load(xq.add(s * 0x7));
-        let x8 = I::load(xq.add(s * 0x8));
-        let x9 = I::load(xq.add(s * 0x9));
-        let xa = I::load(xq.add(s * 0xa));
-        let xb = I::load(xq.add(s * 0xb));
-        let xc = I::load(xq.add(s * 0xc));
-        let xd = I::load(xq.add(s * 0xd));
-        let xe = I::load(xq.add(s * 0xe));
-        let xf = I::load(xq.add(s * 0xf));
-
-        let a08 = I::add(x0, x8);
-        let s08 = I::sub(x0, x8);
-        let a4c = I::add(x4, xc);
-        let s4c = I::sub(x4, xc);
-        let a2a = I::add(x2, xa);
-        let s2a = I::sub(x2, xa);
-        let a6e = I::add(x6, xe);
-        let s6e = I::sub(x6, xe);
-        let a19 = I::add(x1, x9);
-        let s19 = I::sub(x1, x9);
-        let a5d = I::add(x5, xd);
-        let s5d = I::sub(x5, xd);
-        let a3b = I::add(x3, xb);
-        let s3b = I::sub(x3, xb);
-        let a7f = I::add(x7, xf);
-        let s7f = I::sub(x7, xf);
-
-        let js4c = I::xpj(fwd, s4c);
-        let js6e = I::xpj(fwd, s6e);
-        let js5d = I::xpj(fwd, s5d);
-        let js7f = I::xpj(fwd, s7f);
-
-        let a08p1a4c = I::add(a08, a4c);
-        let s08mjs4c = I::sub(s08, js4c);
-        let a08m1a4c = I::sub(a08, a4c);
-        let s08pjs4c = I::add(s08, js4c);
-        let a2ap1a6e = I::add(a2a, a6e);
-        let s2amjs6e = I::sub(s2a, js6e);
-        let a2am1a6e = I::sub(a2a, a6e);
-        let s2apjs6e = I::add(s2a, js6e);
-        let a19p1a5d = I::add(a19, a5d);
-        let s19mjs5d = I::sub(s19, js5d);
-        let a19m1a5d = I::sub(a19, a5d);
-        let s19pjs5d = I::add(s19, js5d);
-        let a3bp1a7f = I::add(a3b, a7f);
-        let s3bmjs7f = I::sub(s3b, js7f);
-        let a3bm1a7f = I::sub(a3b, a7f);
-        let s3bpjs7f = I::add(s3b, js7f);
-
-        let w8_s2amjs6e = I::xw8(fwd, s2amjs6e);
-        let j_a2am1a6e = I::xpj(fwd, a2am1a6e);
-        let v8_s2apjs6e = I::xv8(fwd, s2apjs6e);
-
-        let a08p1a4c_p1_a2ap1a6e = I::add(a08p1a4c, a2ap1a6e);
-        let s08mjs4c_pw_s2amjs6e = I::add(s08mjs4c, w8_s2amjs6e);
-        let a08m1a4c_mj_a2am1a6e = I::sub(a08m1a4c, j_a2am1a6e);
-        let s08pjs4c_mv_s2apjs6e = I::sub(s08pjs4c, v8_s2apjs6e);
-        let a08p1a4c_m1_a2ap1a6e = I::sub(a08p1a4c, a2ap1a6e);
-        let s08mjs4c_mw_s2amjs6e = I::sub(s08mjs4c, w8_s2amjs6e);
-        let a08m1a4c_pj_a2am1a6e = I::add(a08m1a4c, j_a2am1a6e);
-        let s08pjs4c_pv_s2apjs6e = I::add(s08pjs4c, v8_s2apjs6e);
-
-        let w8_s3bmjs7f = I::xw8(fwd, s3bmjs7f);
-        let j_a3bm1a7f = I::xpj(fwd, a3bm1a7f);
-        let v8_s3bpjs7f = I::xv8(fwd, s3bpjs7f);
-
-        let a19p1a5d_p1_a3bp1a7f = I::add(a19p1a5d, a3bp1a7f);
-        let s19mjs5d_pw_s3bmjs7f = I::add(s19mjs5d, w8_s3bmjs7f);
-        let a19m1a5d_mj_a3bm1a7f = I::sub(a19m1a5d, j_a3bm1a7f);
-        let s19pjs5d_mv_s3bpjs7f = I::sub(s19pjs5d, v8_s3bpjs7f);
-        let a19p1a5d_m1_a3bp1a7f = I::sub(a19p1a5d, a3bp1a7f);
-        let s19mjs5d_mw_s3bmjs7f = I::sub(s19mjs5d, w8_s3bmjs7f);
-        let a19m1a5d_pj_a3bm1a7f = I::add(a19m1a5d, j_a3bm1a7f);
-        let s19pjs5d_pv_s3bpjs7f = I::add(s19pjs5d, v8_s3bpjs7f);
-
-        let h1_s19mjs5d_pw_s3bmjs7f = I::xh1(fwd, s19mjs5d_pw_s3bmjs7f);
-        let w8_a19m1a5d_mj_a3bm1a7f = I::xw8(fwd, a19m1a5d_mj_a3bm1a7f);
-        let h3_s19pjs5d_mv_s3bpjs7f = I::xh3(fwd, s19pjs5d_mv_s3bpjs7f);
-        let j_a19p1a5d_m1_a3bp1a7f = I::xpj(fwd, a19p1a5d_m1_a3bp1a7f);
-        let hd_s19mjs5d_mw_s3bmjs7f = I::xhd(fwd, s19mjs5d_mw_s3bmjs7f);
-        let v8_a19m1a5d_pj_a3bm1a7f = I::xv8(fwd, a19m1a5d_pj_a3bm1a7f);
-        let hf_s19pjs5d_pv_s3bpjs7f = I::xhf(fwd, s19pjs5d_pv_s3bpjs7f);
-
-        I::store(
-            zq.add(0),
-            I::add(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f),
-        );
-        I::store(
-            zq.add(s),
-            I::add(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f),
-        );
-        I::store(
-            zq.add(s * 0x2),
-            I::add(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f),
-        );
-        I::store(
-            zq.add(s * 0x3),
-            I::add(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f),
-        );
-        I::store(
-            zq.add(s * 0x4),
-            I::sub(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f),
-        );
-        I::store(
-            zq.add(s * 0x5),
-            I::sub(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f),
-        );
-        I::store(
-            zq.add(s * 0x6),
-            I::sub(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f),
-        );
-        I::store(
-            zq.add(s * 0x7),
-            I::sub(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f),
-        );
-
-        I::store(
-            zq.add(s * 0x8),
-            I::sub(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f),
-        );
-        I::store(
-            zq.add(s * 0x9),
-            I::sub(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f),
-        );
-        I::store(
-            zq.add(s * 0xa),
-            I::sub(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f),
-        );
-        I::store(
-            zq.add(s * 0xb),
-            I::sub(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f),
-        );
-        I::store(
-            zq.add(s * 0xc),
-            I::add(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f),
-        );
-        I::store(
-            zq.add(s * 0xd),
-            I::add(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f),
-        );
-        I::store(
-            zq.add(s * 0xe),
-            I::add(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f),
-        );
-        I::store(
-            zq.add(s * 0xf),
-            I::add(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f),
-        );
-
-        q += I::COMPLEX_PER_REG;
-    }
-}
-
-macro_rules! dif16_impl {
+    let (slice01234567, slice89abcdef) = split_2(slice);
+    let (slice0, slice1, slice2, slice3, slice4, slice5, slice6, slice7) = split_8(slice01234567);
+    let (slice8, slice9, slicea, sliceb, slicec, sliced, slicee, slicef) = split_8(slice89abcdef);
     (
-        $(
-            $(#[$attr: meta])*
-            pub static $fft: ident = Fft {
-                core_1: $core1______: expr,
-                native: $xn: ty,
-                x1: $x1: ty,
-                $(target: $target: tt,)?
-            };
-        )*
-    ) => {
-        $(
-            #[allow(missing_copy_implementations)]
-            #[allow(non_camel_case_types)]
-            #[allow(dead_code)]
-            $(#[$attr])*
-            struct $fft {
-                __private: (),
-            }
-            #[allow(unused_variables)]
-            #[allow(dead_code)]
-            $(#[$attr])*
-            impl $fft {
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_00<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {}
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_01<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$x1>(FWD, 1 << 1, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_02<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$x1>(FWD, 1 << 2, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_03<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_8::<$x1>(FWD, 1 << 3, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_04<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end16::<$x1>(FWD, 1 << 4, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_05<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 5, 1 << 0, x, y, w);
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 4, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_06<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 6, 1 << 0, x, y, w);
-                    end_4::<$xn>(FWD, 1 << 2, 1 << 4, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_07<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 7, 1 << 0, x, y, w);
-                    end_8::<$xn>(FWD, 1 << 3, 1 << 4, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_08<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 8, 1 << 0, x, y, w);
-                    end16::<$xn>(FWD, 1 << 4, 1 << 4, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_09<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 9, 1 << 0, x, y, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 4, y, x, w);
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 8, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_10<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 10, 1 << 0, x, y, w);
-                    core_::<$xn>(FWD, 1 << 06, 1 << 4, y, x, w);
-                    end_4::<$xn>(FWD, 1 << 02, 1 << 8, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_11<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 11, 1 << 00, x, y, w);
-                    core_::<$xn>(FWD, 1 << 07, 1 << 04, y, x, w);
-                    end_8::<$xn>(FWD, 1 << 03, 1 << 08, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_12<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 12, 1 << 00, x, y, w);
-                    core_::<$xn>(FWD, 1 << 08, 1 << 04, y, x, w);
-                    end16::<$xn>(FWD, 1 << 04, 1 << 08, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_13<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 13, 1 << 00, x, y, w);
-                    core_::<$xn>(FWD, 1 << 09, 1 << 04, y, x, w);
-                    core_::<$xn>(FWD, 1 << 05, 1 << 08, x, y, w);
-                    end_2::<$xn>(FWD, 1 << 01, 1 << 12, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_14<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 14, 1 << 00, x, y, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 04, y, x, w);
-                    core_::<$xn>(FWD, 1 << 06, 1 << 08, x, y, w);
-                    end_4::<$xn>(FWD, 1 << 02, 1 << 12, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_15<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 15, 1 << 00, x, y, w);
-                    core_::<$xn>(FWD, 1 << 11, 1 << 04, y, x, w);
-                    core_::<$xn>(FWD, 1 << 07, 1 << 08, x, y, w);
-                    end_8::<$xn>(FWD, 1 << 03, 1 << 12, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_16<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 16, 1 << 00, x, y, w);
-                    core_::<$xn>(FWD, 1 << 12, 1 << 04, y, x, w);
-                    core_::<$xn>(FWD, 1 << 08, 1 << 08, x, y, w);
-                    end16::<$xn>(FWD, 1 << 04, 1 << 12, y, x, true);
-                }
-            }
-            $(#[$attr])*
-            pub(crate) static $fft: crate::FftImpl = crate::FftImpl {
-                fwd: [
-                    <$fft>::fft_00::<true>,
-                    <$fft>::fft_01::<true>,
-                    <$fft>::fft_02::<true>,
-                    <$fft>::fft_03::<true>,
-                    <$fft>::fft_04::<true>,
-                    <$fft>::fft_05::<true>,
-                    <$fft>::fft_06::<true>,
-                    <$fft>::fft_07::<true>,
-                    <$fft>::fft_08::<true>,
-                    <$fft>::fft_09::<true>,
-                    <$fft>::fft_10::<true>,
-                    <$fft>::fft_11::<true>,
-                    <$fft>::fft_12::<true>,
-                    <$fft>::fft_13::<true>,
-                    <$fft>::fft_14::<true>,
-                    <$fft>::fft_15::<true>,
-                    <$fft>::fft_16::<true>,
-                ],
-                inv: [
-                    <$fft>::fft_00::<false>,
-                    <$fft>::fft_01::<false>,
-                    <$fft>::fft_02::<false>,
-                    <$fft>::fft_03::<false>,
-                    <$fft>::fft_04::<false>,
-                    <$fft>::fft_05::<false>,
-                    <$fft>::fft_06::<false>,
-                    <$fft>::fft_07::<false>,
-                    <$fft>::fft_08::<false>,
-                    <$fft>::fft_09::<false>,
-                    <$fft>::fft_10::<false>,
-                    <$fft>::fft_11::<false>,
-                    <$fft>::fft_12::<false>,
-                    <$fft>::fft_13::<false>,
-                    <$fft>::fft_14::<false>,
-                    <$fft>::fft_15::<false>,
-                    <$fft>::fft_16::<false>,
-                ],
-            };
-            )*
-    };
+        slice0, slice1, slice2, slice3, slice4, slice5, slice6, slice7, slice8, slice9, slicea,
+        sliceb, slicec, sliced, slicee, slicef,
+    )
+}
+#[inline(always)]
+pub fn split_mut_16<T>(
+    slice: &mut [T],
+) -> (
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+) {
+    let (slice01234567, slice89abcdef) = split_mut_2(slice);
+    let (slice0, slice1, slice2, slice3, slice4, slice5, slice6, slice7) =
+        split_mut_8(slice01234567);
+    let (slice8, slice9, slicea, sliceb, slicec, sliced, slicee, slicef) =
+        split_mut_8(slice89abcdef);
+    (
+        slice0, slice1, slice2, slice3, slice4, slice5, slice6, slice7, slice8, slice9, slicea,
+        sliceb, slicec, sliced, slicee, slicef,
+    )
 }
 
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-use crate::x86::*;
+#[inline(always)]
+fn stockham_core_1x2<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    s: usize,
+    x: &[c64xN],
+    y: &mut [c64xN],
+    w_init: &[c64xN],
+    _w: &[c64],
+) {
+    assert_eq!(s, 1);
 
-dif16_impl! {
-    pub static DIF16_SCALAR = Fft {
-        core_1: core_::<Scalar>,
-        native: Scalar,
-        x1: Scalar,
-    };
+    let y = pulp::as_arrays_mut::<16, _>(y).0;
+    let (x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf) = split_16(x);
+    let (_, w1, w2, w3, w4, w5, w6, w7, w8, w9, wa, wb, wc, wd, we, wf) = split_16(w_init);
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub static DIF16_AVX = Fft {
-        core_1: core_x2::<AvxX2>,
-        native: AvxX2,
-        x1: AvxX1,
-        target: "avx",
-    };
+    for (
+        (x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf),
+        y,
+        (w1, w2, w3, w4, w5, w6, w7, w8, w9, wa, wb, wc, wd, we, wf),
+    ) in izip!(
+        izip!(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf),
+        y,
+        izip!(w1, w2, w3, w4, w5, w6, w7, w8, w9, wa, wb, wc, wd, we, wf),
+    ) {
+        let x0 = *x0;
+        let x1 = *x1;
+        let x2 = *x2;
+        let x3 = *x3;
+        let x4 = *x4;
+        let x5 = *x5;
+        let x6 = *x6;
+        let x7 = *x7;
+        let x8 = *x8;
+        let x9 = *x9;
+        let xa = *xa;
+        let xb = *xb;
+        let xc = *xc;
+        let xd = *xd;
+        let xe = *xe;
+        let xf = *xf;
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub static DIF16_FMA = Fft {
-        core_1: core_x2::<FmaX2>,
-        native: FmaX2,
-        x1: FmaX1,
-        target: "fma",
-    };
+        let a08 = simd.add(x0, x8);
+        let s08 = simd.sub(x0, x8);
+        let a4c = simd.add(x4, xc);
+        let s4c = simd.sub(x4, xc);
+        let a2a = simd.add(x2, xa);
+        let s2a = simd.sub(x2, xa);
+        let a6e = simd.add(x6, xe);
+        let s6e = simd.sub(x6, xe);
+        let a19 = simd.add(x1, x9);
+        let s19 = simd.sub(x1, x9);
+        let a5d = simd.add(x5, xd);
+        let s5d = simd.sub(x5, xd);
+        let a3b = simd.add(x3, xb);
+        let s3b = simd.sub(x3, xb);
+        let a7f = simd.add(x7, xf);
+        let s7f = simd.sub(x7, xf);
 
-    #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
-    pub static DIF16_AVX512 = Fft {
-        core_1: core_x4::<Avx512X2, Avx512X4>,
-        native: Avx512X4,
-        x1: Avx512X1,
-        target: "avx512f",
-    };
+        let js4c = simd.mul_j(fwd, s4c);
+        let js6e = simd.mul_j(fwd, s6e);
+        let js5d = simd.mul_j(fwd, s5d);
+        let js7f = simd.mul_j(fwd, s7f);
+
+        let a08p1a4c = simd.add(a08, a4c);
+        let s08mjs4c = simd.sub(s08, js4c);
+        let a08m1a4c = simd.sub(a08, a4c);
+        let s08pjs4c = simd.add(s08, js4c);
+        let a2ap1a6e = simd.add(a2a, a6e);
+        let s2amjs6e = simd.sub(s2a, js6e);
+        let a2am1a6e = simd.sub(a2a, a6e);
+        let s2apjs6e = simd.add(s2a, js6e);
+        let a19p1a5d = simd.add(a19, a5d);
+        let s19mjs5d = simd.sub(s19, js5d);
+        let a19m1a5d = simd.sub(a19, a5d);
+        let s19pjs5d = simd.add(s19, js5d);
+        let a3bp1a7f = simd.add(a3b, a7f);
+        let s3bmjs7f = simd.sub(s3b, js7f);
+        let a3bm1a7f = simd.sub(a3b, a7f);
+        let s3bpjs7f = simd.add(s3b, js7f);
+
+        let w8_s2amjs6e = simd.mul_exp_neg_pi_over_8(fwd, s2amjs6e);
+        let j_a2am1a6e = simd.mul_j(fwd, a2am1a6e);
+        let v8_s2apjs6e = simd.mul_exp_pi_over_8(fwd, s2apjs6e);
+
+        let a08p1a4c_p1_a2ap1a6e = simd.add(a08p1a4c, a2ap1a6e);
+        let s08mjs4c_pw_s2amjs6e = simd.add(s08mjs4c, w8_s2amjs6e);
+        let a08m1a4c_mj_a2am1a6e = simd.sub(a08m1a4c, j_a2am1a6e);
+        let s08pjs4c_mv_s2apjs6e = simd.sub(s08pjs4c, v8_s2apjs6e);
+        let a08p1a4c_m1_a2ap1a6e = simd.sub(a08p1a4c, a2ap1a6e);
+        let s08mjs4c_mw_s2amjs6e = simd.sub(s08mjs4c, w8_s2amjs6e);
+        let a08m1a4c_pj_a2am1a6e = simd.add(a08m1a4c, j_a2am1a6e);
+        let s08pjs4c_pv_s2apjs6e = simd.add(s08pjs4c, v8_s2apjs6e);
+
+        let w8_s3bmjs7f = simd.mul_exp_neg_pi_over_8(fwd, s3bmjs7f);
+        let j_a3bm1a7f = simd.mul_j(fwd, a3bm1a7f);
+        let v8_s3bpjs7f = simd.mul_exp_pi_over_8(fwd, s3bpjs7f);
+
+        let a19p1a5d_p1_a3bp1a7f = simd.add(a19p1a5d, a3bp1a7f);
+        let s19mjs5d_pw_s3bmjs7f = simd.add(s19mjs5d, w8_s3bmjs7f);
+        let a19m1a5d_mj_a3bm1a7f = simd.sub(a19m1a5d, j_a3bm1a7f);
+        let s19pjs5d_mv_s3bpjs7f = simd.sub(s19pjs5d, v8_s3bpjs7f);
+        let a19p1a5d_m1_a3bp1a7f = simd.sub(a19p1a5d, a3bp1a7f);
+        let s19mjs5d_mw_s3bmjs7f = simd.sub(s19mjs5d, w8_s3bmjs7f);
+        let a19m1a5d_pj_a3bm1a7f = simd.add(a19m1a5d, j_a3bm1a7f);
+        let s19pjs5d_pv_s3bpjs7f = simd.add(s19pjs5d, v8_s3bpjs7f);
+
+        let h1_s19mjs5d_pw_s3bmjs7f = simd.mul_exp_pi_over_16(fwd, s19mjs5d_pw_s3bmjs7f);
+        let w8_a19m1a5d_mj_a3bm1a7f = simd.mul_exp_neg_pi_over_8(fwd, a19m1a5d_mj_a3bm1a7f);
+        let h3_s19pjs5d_mv_s3bpjs7f = simd.mul_exp_17pi_over_16(fwd, s19pjs5d_mv_s3bpjs7f);
+        let j_a19p1a5d_m1_a3bp1a7f = simd.mul_j(fwd, a19p1a5d_m1_a3bp1a7f);
+        let hd_s19mjs5d_mw_s3bmjs7f = simd.mul_exp_neg_17pi_over_16(fwd, s19mjs5d_mw_s3bmjs7f);
+        let v8_a19m1a5d_pj_a3bm1a7f = simd.mul_exp_pi_over_8(fwd, a19m1a5d_pj_a3bm1a7f);
+        let hf_s19pjs5d_pv_s3bpjs7f = simd.mul_exp_neg_pi_over_16(fwd, s19pjs5d_pv_s3bpjs7f);
+
+        let w1 = *w1;
+        let w2 = *w2;
+        let w3 = *w3;
+        let w4 = *w4;
+        let w5 = *w5;
+        let w6 = *w6;
+        let w7 = *w7;
+        let w8 = *w8;
+        let w9 = *w9;
+        let wa = *wa;
+        let wb = *wb;
+        let wc = *wc;
+        let wd = *wd;
+        let we = *we;
+        let wf = *wf;
+
+        let aa = simd.add(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f);
+        let bb = simd.mul(w1, simd.add(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f));
+        let cc = simd.mul(w2, simd.add(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f));
+        let dd = simd.mul(w3, simd.add(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f));
+        let ee = simd.mul(w4, simd.sub(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f));
+        let ff = simd.mul(w5, simd.sub(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f));
+        let gg = simd.mul(w6, simd.sub(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f));
+        let hh = simd.mul(w7, simd.sub(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f));
+
+        let ii = simd.mul(w8, simd.sub(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f));
+        let jj = simd.mul(w9, simd.sub(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f));
+        let kk = simd.mul(wa, simd.sub(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f));
+        let ll = simd.mul(wb, simd.sub(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f));
+        let mm = simd.mul(wc, simd.add(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f));
+        let nn = simd.mul(wd, simd.add(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f));
+        let oo = simd.mul(we, simd.add(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f));
+        let pp = simd.mul(wf, simd.add(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f));
+
+        let ab = simd.catlo(aa, bb);
+        y[0] = ab;
+        let cd = simd.catlo(cc, dd);
+        y[1] = cd;
+        let ef = simd.catlo(ee, ff);
+        y[2] = ef;
+        let gh = simd.catlo(gg, hh);
+        y[3] = gh;
+
+        let ab = simd.cathi(aa, bb);
+        y[4] = ab;
+        let cd = simd.cathi(cc, dd);
+        y[5] = cd;
+        let ef = simd.cathi(ee, ff);
+        y[6] = ef;
+        let gh = simd.cathi(gg, hh);
+        y[7] = gh;
+
+        let ab = simd.catlo(aa, bb);
+        y[0x0] = ab;
+        let cd = simd.catlo(cc, dd);
+        y[0x1] = cd;
+        let ef = simd.catlo(ee, ff);
+        y[0x2] = ef;
+        let gh = simd.catlo(gg, hh);
+        y[0x3] = gh;
+        let ij = simd.catlo(ii, jj);
+        y[0x4] = ij;
+        let kl = simd.catlo(kk, ll);
+        y[0x5] = kl;
+        let mn = simd.catlo(mm, nn);
+        y[0x6] = mn;
+        let op = simd.catlo(oo, pp);
+        y[0x7] = op;
+        let ab = simd.cathi(aa, bb);
+        y[0x8] = ab;
+        let cd = simd.cathi(cc, dd);
+        y[0x9] = cd;
+        let ef = simd.cathi(ee, ff);
+        y[0xa] = ef;
+        let gh = simd.cathi(gg, hh);
+        y[0xb] = gh;
+        let ij = simd.cathi(ii, jj);
+        y[0xc] = ij;
+        let kl = simd.cathi(kk, ll);
+        y[0xd] = kl;
+        let mn = simd.cathi(mm, nn);
+        y[0xe] = mn;
+        let op = simd.cathi(oo, pp);
+        y[0xf] = op;
+    }
 }
 
-pub(crate) fn runtime_fft() -> crate::FftImpl {
-    #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
-    if x86_feature_detected!("avx512f") {
-        return DIF16_AVX512;
-    }
+#[inline(always)]
+fn stockham_core_1x4<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    s: usize,
+    x: &[c64xN],
+    y: &mut [c64xN],
+    w_init: &[c64xN],
+    _w: &[c64],
+) {
+    assert_eq!(s, 1);
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    if x86_feature_detected!("fma") {
-        return DIF16_FMA;
-    } else if x86_feature_detected!("avx") {
-        return DIF16_AVX;
-    }
+    let y = pulp::as_arrays_mut::<16, _>(y).0;
+    let (x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf) = split_16(x);
+    let (_, w1, w2, w3, w4, w5, w6, w7, w8, w9, wa, wb, wc, wd, we, wf) = split_16(w_init);
 
-    DIF16_SCALAR
+    for (
+        (x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf),
+        y,
+        (w1, w2, w3, w4, w5, w6, w7, w8, w9, wa, wb, wc, wd, we, wf),
+    ) in izip!(
+        izip!(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf),
+        y,
+        izip!(w1, w2, w3, w4, w5, w6, w7, w8, w9, wa, wb, wc, wd, we, wf),
+    ) {
+        let x0 = *x0;
+        let x1 = *x1;
+        let x2 = *x2;
+        let x3 = *x3;
+        let x4 = *x4;
+        let x5 = *x5;
+        let x6 = *x6;
+        let x7 = *x7;
+        let x8 = *x8;
+        let x9 = *x9;
+        let xa = *xa;
+        let xb = *xb;
+        let xc = *xc;
+        let xd = *xd;
+        let xe = *xe;
+        let xf = *xf;
+
+        let a08 = simd.add(x0, x8);
+        let s08 = simd.sub(x0, x8);
+        let a4c = simd.add(x4, xc);
+        let s4c = simd.sub(x4, xc);
+        let a2a = simd.add(x2, xa);
+        let s2a = simd.sub(x2, xa);
+        let a6e = simd.add(x6, xe);
+        let s6e = simd.sub(x6, xe);
+        let a19 = simd.add(x1, x9);
+        let s19 = simd.sub(x1, x9);
+        let a5d = simd.add(x5, xd);
+        let s5d = simd.sub(x5, xd);
+        let a3b = simd.add(x3, xb);
+        let s3b = simd.sub(x3, xb);
+        let a7f = simd.add(x7, xf);
+        let s7f = simd.sub(x7, xf);
+
+        let js4c = simd.mul_j(fwd, s4c);
+        let js6e = simd.mul_j(fwd, s6e);
+        let js5d = simd.mul_j(fwd, s5d);
+        let js7f = simd.mul_j(fwd, s7f);
+
+        let a08p1a4c = simd.add(a08, a4c);
+        let s08mjs4c = simd.sub(s08, js4c);
+        let a08m1a4c = simd.sub(a08, a4c);
+        let s08pjs4c = simd.add(s08, js4c);
+        let a2ap1a6e = simd.add(a2a, a6e);
+        let s2amjs6e = simd.sub(s2a, js6e);
+        let a2am1a6e = simd.sub(a2a, a6e);
+        let s2apjs6e = simd.add(s2a, js6e);
+        let a19p1a5d = simd.add(a19, a5d);
+        let s19mjs5d = simd.sub(s19, js5d);
+        let a19m1a5d = simd.sub(a19, a5d);
+        let s19pjs5d = simd.add(s19, js5d);
+        let a3bp1a7f = simd.add(a3b, a7f);
+        let s3bmjs7f = simd.sub(s3b, js7f);
+        let a3bm1a7f = simd.sub(a3b, a7f);
+        let s3bpjs7f = simd.add(s3b, js7f);
+
+        let w8_s2amjs6e = simd.mul_exp_neg_pi_over_8(fwd, s2amjs6e);
+        let j_a2am1a6e = simd.mul_j(fwd, a2am1a6e);
+        let v8_s2apjs6e = simd.mul_exp_pi_over_8(fwd, s2apjs6e);
+
+        let a08p1a4c_p1_a2ap1a6e = simd.add(a08p1a4c, a2ap1a6e);
+        let s08mjs4c_pw_s2amjs6e = simd.add(s08mjs4c, w8_s2amjs6e);
+        let a08m1a4c_mj_a2am1a6e = simd.sub(a08m1a4c, j_a2am1a6e);
+        let s08pjs4c_mv_s2apjs6e = simd.sub(s08pjs4c, v8_s2apjs6e);
+        let a08p1a4c_m1_a2ap1a6e = simd.sub(a08p1a4c, a2ap1a6e);
+        let s08mjs4c_mw_s2amjs6e = simd.sub(s08mjs4c, w8_s2amjs6e);
+        let a08m1a4c_pj_a2am1a6e = simd.add(a08m1a4c, j_a2am1a6e);
+        let s08pjs4c_pv_s2apjs6e = simd.add(s08pjs4c, v8_s2apjs6e);
+
+        let w8_s3bmjs7f = simd.mul_exp_neg_pi_over_8(fwd, s3bmjs7f);
+        let j_a3bm1a7f = simd.mul_j(fwd, a3bm1a7f);
+        let v8_s3bpjs7f = simd.mul_exp_pi_over_8(fwd, s3bpjs7f);
+
+        let a19p1a5d_p1_a3bp1a7f = simd.add(a19p1a5d, a3bp1a7f);
+        let s19mjs5d_pw_s3bmjs7f = simd.add(s19mjs5d, w8_s3bmjs7f);
+        let a19m1a5d_mj_a3bm1a7f = simd.sub(a19m1a5d, j_a3bm1a7f);
+        let s19pjs5d_mv_s3bpjs7f = simd.sub(s19pjs5d, v8_s3bpjs7f);
+        let a19p1a5d_m1_a3bp1a7f = simd.sub(a19p1a5d, a3bp1a7f);
+        let s19mjs5d_mw_s3bmjs7f = simd.sub(s19mjs5d, w8_s3bmjs7f);
+        let a19m1a5d_pj_a3bm1a7f = simd.add(a19m1a5d, j_a3bm1a7f);
+        let s19pjs5d_pv_s3bpjs7f = simd.add(s19pjs5d, v8_s3bpjs7f);
+
+        let h1_s19mjs5d_pw_s3bmjs7f = simd.mul_exp_pi_over_16(fwd, s19mjs5d_pw_s3bmjs7f);
+        let w8_a19m1a5d_mj_a3bm1a7f = simd.mul_exp_neg_pi_over_8(fwd, a19m1a5d_mj_a3bm1a7f);
+        let h3_s19pjs5d_mv_s3bpjs7f = simd.mul_exp_17pi_over_16(fwd, s19pjs5d_mv_s3bpjs7f);
+        let j_a19p1a5d_m1_a3bp1a7f = simd.mul_j(fwd, a19p1a5d_m1_a3bp1a7f);
+        let hd_s19mjs5d_mw_s3bmjs7f = simd.mul_exp_neg_17pi_over_16(fwd, s19mjs5d_mw_s3bmjs7f);
+        let v8_a19m1a5d_pj_a3bm1a7f = simd.mul_exp_pi_over_8(fwd, a19m1a5d_pj_a3bm1a7f);
+        let hf_s19pjs5d_pv_s3bpjs7f = simd.mul_exp_neg_pi_over_16(fwd, s19pjs5d_pv_s3bpjs7f);
+
+        let w1 = *w1;
+        let w2 = *w2;
+        let w3 = *w3;
+        let w4 = *w4;
+        let w5 = *w5;
+        let w6 = *w6;
+        let w7 = *w7;
+        let w8 = *w8;
+        let w9 = *w9;
+        let wa = *wa;
+        let wb = *wb;
+        let wc = *wc;
+        let wd = *wd;
+        let we = *we;
+        let wf = *wf;
+
+        let a_ = simd.add(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f);
+        let b_ = simd.mul(w1, simd.add(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f));
+        let c_ = simd.mul(w2, simd.add(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f));
+        let d_ = simd.mul(w3, simd.add(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f));
+        let e_ = simd.mul(w4, simd.sub(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f));
+        let f_ = simd.mul(w5, simd.sub(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f));
+        let g_ = simd.mul(w6, simd.sub(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f));
+        let h_ = simd.mul(w7, simd.sub(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f));
+
+        let i_ = simd.mul(w8, simd.sub(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f));
+        let j_ = simd.mul(w9, simd.sub(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f));
+        let k_ = simd.mul(wa, simd.sub(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f));
+        let l_ = simd.mul(wb, simd.sub(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f));
+        let m_ = simd.mul(wc, simd.add(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f));
+        let n_ = simd.mul(wd, simd.add(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f));
+        let o_ = simd.mul(we, simd.add(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f));
+        let p_ = simd.mul(wf, simd.add(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f));
+
+        let (abcd0, abcd1, abcd2, abcd3) = simd.transpose(a_, b_, c_, d_);
+        let (efgh0, efgh1, efgh2, efgh3) = simd.transpose(e_, f_, g_, h_);
+        let (ijkl0, ijkl1, ijkl2, ijkl3) = simd.transpose(i_, j_, k_, l_);
+        let (mnop0, mnop1, mnop2, mnop3) = simd.transpose(m_, n_, o_, p_);
+
+        y[0x0] = abcd0;
+        y[0x1] = efgh0;
+        y[0x2] = ijkl0;
+        y[0x3] = mnop0;
+
+        y[0x4] = abcd1;
+        y[0x5] = efgh1;
+        y[0x6] = ijkl1;
+        y[0x7] = mnop1;
+
+        y[0x8] = abcd2;
+        y[0x9] = efgh2;
+        y[0xa] = ijkl2;
+        y[0xb] = mnop2;
+
+        y[0xc] = abcd3;
+        y[0xd] = efgh3;
+        y[0xe] = ijkl3;
+        y[0xf] = mnop3;
+    }
+}
+
+#[inline(always)]
+fn stockham_core_generic<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    s: usize,
+    x: &[c64xN],
+    y: &mut [c64xN],
+    _w_init: &[c64xN],
+    w: &[c64],
+) {
+    assert_eq!(s % simd.lane_count(), 0);
+    let simd_s = s / simd.lane_count();
+
+    let w = pulp::as_arrays::<16, _>(w).0;
+
+    let (x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf) = split_16(x);
+
+    for ((x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf), y, w) in izip!(
+        izip!(
+            x0.chunks_exact(simd_s),
+            x1.chunks_exact(simd_s),
+            x2.chunks_exact(simd_s),
+            x3.chunks_exact(simd_s),
+            x4.chunks_exact(simd_s),
+            x5.chunks_exact(simd_s),
+            x6.chunks_exact(simd_s),
+            x7.chunks_exact(simd_s),
+            x8.chunks_exact(simd_s),
+            x9.chunks_exact(simd_s),
+            xa.chunks_exact(simd_s),
+            xb.chunks_exact(simd_s),
+            xc.chunks_exact(simd_s),
+            xd.chunks_exact(simd_s),
+            xe.chunks_exact(simd_s),
+            xf.chunks_exact(simd_s),
+        ),
+        y.chunks_exact_mut(16 * simd_s),
+        w.chunks_exact(s),
+    ) {
+        let [_, w1, w2, w3, w4, w5, w6, w7, w8, w9, wa, wb, wc, wd, we, wf] = w[0];
+
+        let w1 = simd.splat(w1);
+        let w2 = simd.splat(w2);
+        let w3 = simd.splat(w3);
+        let w4 = simd.splat(w4);
+        let w5 = simd.splat(w5);
+        let w6 = simd.splat(w6);
+        let w7 = simd.splat(w7);
+        let w8 = simd.splat(w8);
+        let w9 = simd.splat(w9);
+        let wa = simd.splat(wa);
+        let wb = simd.splat(wb);
+        let wc = simd.splat(wc);
+        let wd = simd.splat(wd);
+        let we = simd.splat(we);
+        let wf = simd.splat(wf);
+
+        let (y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, ya, yb, yc, yd, ye, yf) = split_mut_16(y);
+
+        for (
+            (x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf),
+            (y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, ya, yb, yc, yd, ye, yf),
+        ) in izip!(
+            izip!(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf),
+            izip!(y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, ya, yb, yc, yd, ye, yf),
+        ) {
+            let x0 = *x0;
+            let x1 = *x1;
+            let x2 = *x2;
+            let x3 = *x3;
+            let x4 = *x4;
+            let x5 = *x5;
+            let x6 = *x6;
+            let x7 = *x7;
+            let x8 = *x8;
+            let x9 = *x9;
+            let xa = *xa;
+            let xb = *xb;
+            let xc = *xc;
+            let xd = *xd;
+            let xe = *xe;
+            let xf = *xf;
+
+            let a08 = simd.add(x0, x8);
+            let s08 = simd.sub(x0, x8);
+            let a4c = simd.add(x4, xc);
+            let s4c = simd.sub(x4, xc);
+            let a2a = simd.add(x2, xa);
+            let s2a = simd.sub(x2, xa);
+            let a6e = simd.add(x6, xe);
+            let s6e = simd.sub(x6, xe);
+            let a19 = simd.add(x1, x9);
+            let s19 = simd.sub(x1, x9);
+            let a5d = simd.add(x5, xd);
+            let s5d = simd.sub(x5, xd);
+            let a3b = simd.add(x3, xb);
+            let s3b = simd.sub(x3, xb);
+            let a7f = simd.add(x7, xf);
+            let s7f = simd.sub(x7, xf);
+
+            let js4c = simd.mul_j(fwd, s4c);
+            let js6e = simd.mul_j(fwd, s6e);
+            let js5d = simd.mul_j(fwd, s5d);
+            let js7f = simd.mul_j(fwd, s7f);
+
+            let a08p1a4c = simd.add(a08, a4c);
+            let s08mjs4c = simd.sub(s08, js4c);
+            let a08m1a4c = simd.sub(a08, a4c);
+            let s08pjs4c = simd.add(s08, js4c);
+            let a2ap1a6e = simd.add(a2a, a6e);
+            let s2amjs6e = simd.sub(s2a, js6e);
+            let a2am1a6e = simd.sub(a2a, a6e);
+            let s2apjs6e = simd.add(s2a, js6e);
+            let a19p1a5d = simd.add(a19, a5d);
+            let s19mjs5d = simd.sub(s19, js5d);
+            let a19m1a5d = simd.sub(a19, a5d);
+            let s19pjs5d = simd.add(s19, js5d);
+            let a3bp1a7f = simd.add(a3b, a7f);
+            let s3bmjs7f = simd.sub(s3b, js7f);
+            let a3bm1a7f = simd.sub(a3b, a7f);
+            let s3bpjs7f = simd.add(s3b, js7f);
+
+            let w8_s2amjs6e = simd.mul_exp_neg_pi_over_8(fwd, s2amjs6e);
+            let j_a2am1a6e = simd.mul_j(fwd, a2am1a6e);
+            let v8_s2apjs6e = simd.mul_exp_pi_over_8(fwd, s2apjs6e);
+
+            let a08p1a4c_p1_a2ap1a6e = simd.add(a08p1a4c, a2ap1a6e);
+            let s08mjs4c_pw_s2amjs6e = simd.add(s08mjs4c, w8_s2amjs6e);
+            let a08m1a4c_mj_a2am1a6e = simd.sub(a08m1a4c, j_a2am1a6e);
+            let s08pjs4c_mv_s2apjs6e = simd.sub(s08pjs4c, v8_s2apjs6e);
+            let a08p1a4c_m1_a2ap1a6e = simd.sub(a08p1a4c, a2ap1a6e);
+            let s08mjs4c_mw_s2amjs6e = simd.sub(s08mjs4c, w8_s2amjs6e);
+            let a08m1a4c_pj_a2am1a6e = simd.add(a08m1a4c, j_a2am1a6e);
+            let s08pjs4c_pv_s2apjs6e = simd.add(s08pjs4c, v8_s2apjs6e);
+
+            let w8_s3bmjs7f = simd.mul_exp_neg_pi_over_8(fwd, s3bmjs7f);
+            let j_a3bm1a7f = simd.mul_j(fwd, a3bm1a7f);
+            let v8_s3bpjs7f = simd.mul_exp_pi_over_8(fwd, s3bpjs7f);
+
+            let a19p1a5d_p1_a3bp1a7f = simd.add(a19p1a5d, a3bp1a7f);
+            let s19mjs5d_pw_s3bmjs7f = simd.add(s19mjs5d, w8_s3bmjs7f);
+            let a19m1a5d_mj_a3bm1a7f = simd.sub(a19m1a5d, j_a3bm1a7f);
+            let s19pjs5d_mv_s3bpjs7f = simd.sub(s19pjs5d, v8_s3bpjs7f);
+            let a19p1a5d_m1_a3bp1a7f = simd.sub(a19p1a5d, a3bp1a7f);
+            let s19mjs5d_mw_s3bmjs7f = simd.sub(s19mjs5d, w8_s3bmjs7f);
+            let a19m1a5d_pj_a3bm1a7f = simd.add(a19m1a5d, j_a3bm1a7f);
+            let s19pjs5d_pv_s3bpjs7f = simd.add(s19pjs5d, v8_s3bpjs7f);
+
+            let h1_s19mjs5d_pw_s3bmjs7f = simd.mul_exp_pi_over_16(fwd, s19mjs5d_pw_s3bmjs7f);
+            let w8_a19m1a5d_mj_a3bm1a7f = simd.mul_exp_neg_pi_over_8(fwd, a19m1a5d_mj_a3bm1a7f);
+            let h3_s19pjs5d_mv_s3bpjs7f = simd.mul_exp_17pi_over_16(fwd, s19pjs5d_mv_s3bpjs7f);
+            let j_a19p1a5d_m1_a3bp1a7f = simd.mul_j(fwd, a19p1a5d_m1_a3bp1a7f);
+            let hd_s19mjs5d_mw_s3bmjs7f = simd.mul_exp_neg_17pi_over_16(fwd, s19mjs5d_mw_s3bmjs7f);
+            let v8_a19m1a5d_pj_a3bm1a7f = simd.mul_exp_pi_over_8(fwd, a19m1a5d_pj_a3bm1a7f);
+            let hf_s19pjs5d_pv_s3bpjs7f = simd.mul_exp_neg_pi_over_16(fwd, s19pjs5d_pv_s3bpjs7f);
+
+            *y0 = simd.add(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f);
+            *y1 = simd.mul(w1, simd.add(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f));
+            *y2 = simd.mul(w2, simd.add(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f));
+            *y3 = simd.mul(w3, simd.add(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f));
+            *y4 = simd.mul(w4, simd.sub(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f));
+            *y5 = simd.mul(w5, simd.sub(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f));
+            *y6 = simd.mul(w6, simd.sub(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f));
+            *y7 = simd.mul(w7, simd.sub(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f));
+
+            *y8 = simd.mul(w8, simd.sub(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f));
+            *y9 = simd.mul(w9, simd.sub(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f));
+            *ya = simd.mul(wa, simd.sub(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f));
+            *yb = simd.mul(wb, simd.sub(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f));
+            *yc = simd.mul(wc, simd.add(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f));
+            *yd = simd.mul(wd, simd.add(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f));
+            *ye = simd.mul(we, simd.add(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f));
+            *yf = simd.mul(wf, simd.add(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f));
+        }
+    }
+}
+
+#[inline(always)]
+fn stockham_core<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    s: usize,
+    x: &[c64xN],
+    y: &mut [c64xN],
+    w_init: &[c64xN],
+    w: &[c64],
+) {
+    // we create a fn pointer that will be force-inlined in release builds
+    // but not in debug builds. this helps keep compile times low, since dead code
+    // elimination handles this well in release builds. and the function pointer indirection
+    // prevents inlining in debug builds.
+    let stockham = if s == 1 && simd.lane_count() == 2 {
+        stockham_core_1x2
+    } else if s == 1 && simd.lane_count() == 4 {
+        stockham_core_1x4
+    } else {
+        stockham_core_generic
+    };
+    stockham(simd, fwd, s, x, y, w_init, w);
+}
+
+#[inline(always)]
+fn last_butterfly<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    x0: c64xN,
+    x1: c64xN,
+    x2: c64xN,
+    x3: c64xN,
+    x4: c64xN,
+    x5: c64xN,
+    x6: c64xN,
+    x7: c64xN,
+    x8: c64xN,
+    x9: c64xN,
+    xa: c64xN,
+    xb: c64xN,
+    xc: c64xN,
+    xd: c64xN,
+    xe: c64xN,
+    xf: c64xN,
+) -> (
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+    c64xN,
+) {
+    let a08 = simd.add(x0, x8);
+    let s08 = simd.sub(x0, x8);
+    let a4c = simd.add(x4, xc);
+    let s4c = simd.sub(x4, xc);
+    let a2a = simd.add(x2, xa);
+    let s2a = simd.sub(x2, xa);
+    let a6e = simd.add(x6, xe);
+    let s6e = simd.sub(x6, xe);
+    let a19 = simd.add(x1, x9);
+    let s19 = simd.sub(x1, x9);
+    let a5d = simd.add(x5, xd);
+    let s5d = simd.sub(x5, xd);
+    let a3b = simd.add(x3, xb);
+    let s3b = simd.sub(x3, xb);
+    let a7f = simd.add(x7, xf);
+    let s7f = simd.sub(x7, xf);
+
+    let js4c = simd.mul_j(fwd, s4c);
+    let js6e = simd.mul_j(fwd, s6e);
+    let js5d = simd.mul_j(fwd, s5d);
+    let js7f = simd.mul_j(fwd, s7f);
+
+    let a08p1a4c = simd.add(a08, a4c);
+    let s08mjs4c = simd.sub(s08, js4c);
+    let a08m1a4c = simd.sub(a08, a4c);
+    let s08pjs4c = simd.add(s08, js4c);
+    let a2ap1a6e = simd.add(a2a, a6e);
+    let s2amjs6e = simd.sub(s2a, js6e);
+    let a2am1a6e = simd.sub(a2a, a6e);
+    let s2apjs6e = simd.add(s2a, js6e);
+    let a19p1a5d = simd.add(a19, a5d);
+    let s19mjs5d = simd.sub(s19, js5d);
+    let a19m1a5d = simd.sub(a19, a5d);
+    let s19pjs5d = simd.add(s19, js5d);
+    let a3bp1a7f = simd.add(a3b, a7f);
+    let s3bmjs7f = simd.sub(s3b, js7f);
+    let a3bm1a7f = simd.sub(a3b, a7f);
+    let s3bpjs7f = simd.add(s3b, js7f);
+
+    let w8_s2amjs6e = simd.mul_exp_neg_pi_over_8(fwd, s2amjs6e);
+    let j_a2am1a6e = simd.mul_j(fwd, a2am1a6e);
+    let v8_s2apjs6e = simd.mul_exp_pi_over_8(fwd, s2apjs6e);
+
+    let a08p1a4c_p1_a2ap1a6e = simd.add(a08p1a4c, a2ap1a6e);
+    let s08mjs4c_pw_s2amjs6e = simd.add(s08mjs4c, w8_s2amjs6e);
+    let a08m1a4c_mj_a2am1a6e = simd.sub(a08m1a4c, j_a2am1a6e);
+    let s08pjs4c_mv_s2apjs6e = simd.sub(s08pjs4c, v8_s2apjs6e);
+    let a08p1a4c_m1_a2ap1a6e = simd.sub(a08p1a4c, a2ap1a6e);
+    let s08mjs4c_mw_s2amjs6e = simd.sub(s08mjs4c, w8_s2amjs6e);
+    let a08m1a4c_pj_a2am1a6e = simd.add(a08m1a4c, j_a2am1a6e);
+    let s08pjs4c_pv_s2apjs6e = simd.add(s08pjs4c, v8_s2apjs6e);
+
+    let w8_s3bmjs7f = simd.mul_exp_neg_pi_over_8(fwd, s3bmjs7f);
+    let j_a3bm1a7f = simd.mul_j(fwd, a3bm1a7f);
+    let v8_s3bpjs7f = simd.mul_exp_pi_over_8(fwd, s3bpjs7f);
+
+    let a19p1a5d_p1_a3bp1a7f = simd.add(a19p1a5d, a3bp1a7f);
+    let s19mjs5d_pw_s3bmjs7f = simd.add(s19mjs5d, w8_s3bmjs7f);
+    let a19m1a5d_mj_a3bm1a7f = simd.sub(a19m1a5d, j_a3bm1a7f);
+    let s19pjs5d_mv_s3bpjs7f = simd.sub(s19pjs5d, v8_s3bpjs7f);
+    let a19p1a5d_m1_a3bp1a7f = simd.sub(a19p1a5d, a3bp1a7f);
+    let s19mjs5d_mw_s3bmjs7f = simd.sub(s19mjs5d, w8_s3bmjs7f);
+    let a19m1a5d_pj_a3bm1a7f = simd.add(a19m1a5d, j_a3bm1a7f);
+    let s19pjs5d_pv_s3bpjs7f = simd.add(s19pjs5d, v8_s3bpjs7f);
+
+    let h1_s19mjs5d_pw_s3bmjs7f = simd.mul_exp_pi_over_16(fwd, s19mjs5d_pw_s3bmjs7f);
+    let w8_a19m1a5d_mj_a3bm1a7f = simd.mul_exp_neg_pi_over_8(fwd, a19m1a5d_mj_a3bm1a7f);
+    let h3_s19pjs5d_mv_s3bpjs7f = simd.mul_exp_17pi_over_16(fwd, s19pjs5d_mv_s3bpjs7f);
+    let j_a19p1a5d_m1_a3bp1a7f = simd.mul_j(fwd, a19p1a5d_m1_a3bp1a7f);
+    let hd_s19mjs5d_mw_s3bmjs7f = simd.mul_exp_neg_17pi_over_16(fwd, s19mjs5d_mw_s3bmjs7f);
+    let v8_a19m1a5d_pj_a3bm1a7f = simd.mul_exp_pi_over_8(fwd, a19m1a5d_pj_a3bm1a7f);
+    let hf_s19pjs5d_pv_s3bpjs7f = simd.mul_exp_neg_pi_over_16(fwd, s19pjs5d_pv_s3bpjs7f);
+
+    (
+        simd.add(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f),
+        simd.add(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f),
+        simd.add(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f),
+        simd.add(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f),
+        simd.sub(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f),
+        simd.sub(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f),
+        simd.sub(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f),
+        simd.sub(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f),
+        simd.sub(a08p1a4c_p1_a2ap1a6e, a19p1a5d_p1_a3bp1a7f),
+        simd.sub(s08mjs4c_pw_s2amjs6e, h1_s19mjs5d_pw_s3bmjs7f),
+        simd.sub(a08m1a4c_mj_a2am1a6e, w8_a19m1a5d_mj_a3bm1a7f),
+        simd.sub(s08pjs4c_mv_s2apjs6e, h3_s19pjs5d_mv_s3bpjs7f),
+        simd.add(a08p1a4c_m1_a2ap1a6e, j_a19p1a5d_m1_a3bp1a7f),
+        simd.add(s08mjs4c_mw_s2amjs6e, hd_s19mjs5d_mw_s3bmjs7f),
+        simd.add(a08m1a4c_pj_a2am1a6e, v8_a19m1a5d_pj_a3bm1a7f),
+        simd.add(s08pjs4c_pv_s2apjs6e, hf_s19pjs5d_pv_s3bpjs7f),
+    )
+}
+
+#[inline(always)]
+pub fn stockham_dif16_end<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    write_to_x: bool,
+    s: usize,
+    x: &mut [c64xN],
+    y: &mut [c64xN],
+) {
+    assert_eq!(s % simd.lane_count(), 0);
+    let (x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf) = split_mut_16(x);
+    let (y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, ya, yb, yc, yd, ye, yf) = split_mut_16(y);
+
+    // we create a fn pointer that will be force-inlined in release builds
+    // but not in debug builds. this helps keep compile times low, since dead code
+    // elimination handles this well in release builds. and the function pointer indirection
+    // prevents inlining in debug builds.
+    let last_butterfly: fn(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) -> _ =
+        last_butterfly;
+
+    if write_to_x {
+        for (x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf) in
+            izip!(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf)
+        {
+            (
+                *x0, *x1, *x2, *x3, *x4, *x5, *x6, *x7, *x8, *x9, *xa, *xb, *xc, *xd, *xe, *xf,
+            ) = last_butterfly(
+                simd, fwd, *x0, *x1, *x2, *x3, *x4, *x5, *x6, *x7, *x8, *x9, *xa, *xb, *xc, *xd,
+                *xe, *xf,
+            );
+        }
+    } else {
+        for (
+            (x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf),
+            (y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, ya, yb, yc, yd, ye, yf),
+        ) in izip!(
+            izip!(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, xa, xb, xc, xd, xe, xf),
+            izip!(y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, ya, yb, yc, yd, ye, yf),
+        ) {
+            (
+                *y0, *y1, *y2, *y3, *y4, *y5, *y6, *y7, *y8, *y9, *ya, *yb, *yc, *yd, *ye, *yf,
+            ) = last_butterfly(
+                simd, fwd, *x0, *x1, *x2, *x3, *x4, *x5, *x6, *x7, *x8, *x9, *xa, *xb, *xc, *xd,
+                *xe, *xf,
+            );
+        }
+    }
+}
+
+struct Dif16<N: nat::Nat>(N);
+impl<N: nat::Nat> nat::Nat for Dif16<N> {
+    const VALUE: usize = N::VALUE;
+}
+
+// size 2
+impl RecursiveFft for Dif16<nat::N0> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        write_to_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        crate::dif2::stockham_dif2_end(simd, fwd, write_to_x, s, x, y);
+    }
+}
+
+// size 4
+impl RecursiveFft for Dif16<nat::N1> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        write_to_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        crate::dif4::stockham_dif4_end(simd, fwd, write_to_x, s, x, y);
+    }
+}
+
+// size 8
+impl RecursiveFft for Dif16<nat::N2> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        write_to_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        crate::dif8::stockham_dif8_end(simd, fwd, write_to_x, s, x, y);
+    }
+}
+
+// size 16
+impl RecursiveFft for Dif16<nat::N3> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        write_to_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        stockham_dif16_end(simd, fwd, write_to_x, s, x, y);
+    }
+}
+
+impl<N: nat::Nat> RecursiveFft for Dif16<nat::Plus4<N>>
+where
+    Dif16<N>: RecursiveFft,
+{
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        write_to_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        w_init: &[c64xN],
+        w: &[c64],
+    ) {
+        stockham_core(simd, fwd, s, x, y, w_init, w);
+        Dif16::<N>::fft_recurse_impl(simd, fwd, !write_to_x, s * 16, y, x, w_init, w);
+    }
+}
+
+pub(crate) fn fft_impl<c64xN: Pod>(simd: impl FftSimd<c64xN>) -> crate::FftImpl {
+    let fwd = [
+        fn_ptr::<true, Dif16<nat::N0>, _, _>(simd),
+        fn_ptr::<true, Dif16<nat::N1>, _, _>(simd),
+        fn_ptr::<true, Dif16<nat::N2>, _, _>(simd),
+        fn_ptr::<true, Dif16<nat::N3>, _, _>(simd),
+        fn_ptr::<true, Dif16<nat::N4>, _, _>(simd),
+        fn_ptr::<true, Dif16<nat::N5>, _, _>(simd),
+        fn_ptr::<true, Dif16<nat::N6>, _, _>(simd),
+        fn_ptr::<true, Dif16<nat::N7>, _, _>(simd),
+        fn_ptr::<true, Dif16<nat::N8>, _, _>(simd),
+        fn_ptr::<true, Dif16<nat::N9>, _, _>(simd),
+    ];
+    let inv = [
+        fn_ptr::<false, Dif16<nat::N0>, _, _>(simd),
+        fn_ptr::<false, Dif16<nat::N1>, _, _>(simd),
+        fn_ptr::<false, Dif16<nat::N2>, _, _>(simd),
+        fn_ptr::<false, Dif16<nat::N3>, _, _>(simd),
+        fn_ptr::<false, Dif16<nat::N4>, _, _>(simd),
+        fn_ptr::<false, Dif16<nat::N5>, _, _>(simd),
+        fn_ptr::<false, Dif16<nat::N6>, _, _>(simd),
+        fn_ptr::<false, Dif16<nat::N7>, _, _>(simd),
+        fn_ptr::<false, Dif16<nat::N8>, _, _>(simd),
+        fn_ptr::<false, Dif16<nat::N9>, _, _>(simd),
+    ];
+    crate::FftImpl { fwd, inv }
+}
+
+pub fn fft_impl_dispatch(n: usize) -> [fn(&mut [c64], &mut [c64], &[c64], &[c64]); 2] {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        #[cfg(feature = "nightly")]
+        if let Some(simd) = pulp::x86::V4::try_new() {
+            if n >= 16 * simd.lane_count() {
+                return fft_impl(simd).make_fn_ptr(n);
+            }
+        }
+        if let Some(simd) = pulp::x86::V3::try_new() {
+            if n >= 16 * simd.lane_count() {
+                return fft_impl(simd).make_fn_ptr(n);
+            }
+        }
+    }
+    fft_impl(crate::fft_simd::Scalar).make_fn_ptr(n)
 }

--- a/src/dif8.rs
+++ b/src/dif8.rs
@@ -1,572 +1,508 @@
-// Copyright (c) 2019 OK Ojisan(Takuya OKAHISA)
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy of
-// this software and associated documentation files (the "Software"), to deal in
-// the Software without restriction, including without limitation the rights to
-// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-// of the Software, and to permit persons to whom the Software is furnished to do
-// so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
-use crate::c64;
-use crate::dif2::end_2;
-use crate::dif4::end_4;
-use crate::fft_simd::{twid, twid_t, FftSimd64, FftSimd64Ext, FftSimd64X2, FftSimd64X4, Scalar};
-use crate::x86_feature_detected;
+use crate::{
+    c64,
+    dif2::{split_2, split_mut_2},
+    dif4::{split_4, split_mut_4},
+    fft_simd::{FftSimd, FftSimdExt, Pod},
+    fn_ptr, nat, RecursiveFft,
+};
 
 #[inline(always)]
-#[rustfmt::skip]
-unsafe fn core_<I: FftSimd64>(
-    fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
-) {
-    debug_assert_eq!(s % I::COMPLEX_PER_REG, 0);
-
-    let m = n / 8;
-    let big_n = n * s;
-    let big_n0 = 0;
-    let big_n1 = big_n / 8;
-    let big_n2 = big_n1 * 2;
-    let big_n3 = big_n1 * 3;
-    let big_n4 = big_n1 * 4;
-    let big_n5 = big_n1 * 5;
-    let big_n6 = big_n1 * 6;
-    let big_n7 = big_n1 * 7;
-
-    for p in 0..m {
-        let sp = s * p;
-        let s8p = 8 * sp;
-        let w1p = I::splat(twid_t(8, big_n, 1, w, sp));
-        let w2p = I::splat(twid_t(8, big_n, 2, w, sp));
-        let w3p = I::splat(twid_t(8, big_n, 3, w, sp));
-        let w4p = I::splat(twid_t(8, big_n, 4, w, sp));
-        let w5p = I::splat(twid_t(8, big_n, 5, w, sp));
-        let w6p = I::splat(twid_t(8, big_n, 6, w, sp));
-        let w7p = I::splat(twid_t(8, big_n, 7, w, sp));
-
-        let mut q = 0;
-        while q < s {
-            let xq_sp = x.add(q + sp);
-            let yq_s8p = y.add(q + s8p);
-
-            let x0 = I::load(xq_sp.add(big_n0));
-            let x1 = I::load(xq_sp.add(big_n1));
-            let x2 = I::load(xq_sp.add(big_n2));
-            let x3 = I::load(xq_sp.add(big_n3));
-            let x4 = I::load(xq_sp.add(big_n4));
-            let x5 = I::load(xq_sp.add(big_n5));
-            let x6 = I::load(xq_sp.add(big_n6));
-            let x7 = I::load(xq_sp.add(big_n7));
-
-            let a04 = I::add(x0, x4);
-            let s04 = I::sub(x0, x4);
-            let a26 = I::add(x2, x6);
-            let js26 = I::xpj(fwd, I::sub(x2, x6));
-            let a15 = I::add(x1, x5);
-            let s15 = I::sub(x1, x5);
-            let a37 = I::add(x3, x7);
-            let js37 = I::xpj(fwd, I::sub(x3, x7));
-            let a04_p1_a26 = I::add(a04, a26);
-            let s04_mj_s26 = I::sub(s04, js26);
-            let a04_m1_a26 = I::sub(a04, a26);
-            let s04_pj_s26 = I::add(s04, js26);
-            let a15_p1_a37 = I::add(a15, a37);
-            let w8_s15_mj_s37 = I::xw8(fwd, I::sub(s15, js37));
-            let j_a15_m1_a37 = I::xpj(fwd, I::sub(a15, a37));
-            let v8_s15_pj_s37 = I::xv8(fwd, I::add(s15, js37));
-
-            I::store(yq_s8p.add(s * 0), I::add(a04_p1_a26, a15_p1_a37));
-            I::store(yq_s8p.add(s * 1), I::mul(w1p, I::add(s04_mj_s26, w8_s15_mj_s37)));
-            I::store(yq_s8p.add(s * 2), I::mul(w2p, I::sub(a04_m1_a26, j_a15_m1_a37)));
-            I::store(yq_s8p.add(s * 3), I::mul(w3p, I::sub(s04_pj_s26, v8_s15_pj_s37)));
-            I::store(yq_s8p.add(s * 4), I::mul(w4p, I::sub(a04_p1_a26, a15_p1_a37)));
-            I::store(yq_s8p.add(s * 5), I::mul(w5p, I::sub(s04_mj_s26, w8_s15_mj_s37)));
-            I::store(yq_s8p.add(s * 6), I::mul(w6p, I::add(a04_m1_a26, j_a15_m1_a37)));
-            I::store(yq_s8p.add(s * 7), I::mul(w7p, I::add(s04_pj_s26, v8_s15_pj_s37)));
-
-            q += I::COMPLEX_PER_REG;
-        }
-    }
-}
-
-#[inline(always)]
-#[allow(dead_code)]
-unsafe fn core_x2<I: FftSimd64X2>(
-    fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
-) {
-    debug_assert_eq!(s, 1);
-
-    let big_n = n;
-    let big_n0 = 0;
-    let big_n1 = big_n / 8;
-    let big_n2 = big_n1 * 2;
-    let big_n3 = big_n1 * 3;
-    let big_n4 = big_n1 * 4;
-    let big_n5 = big_n1 * 5;
-    let big_n6 = big_n1 * 6;
-    let big_n7 = big_n1 * 7;
-
-    debug_assert_eq!(big_n1 % 2, 0);
-    let mut p = 0;
-    while p < big_n1 {
-        let x_p = x.add(p);
-        let y_8p = y.add(8 * p);
-
-        let x0 = I::load(x_p.add(big_n0));
-        let x1 = I::load(x_p.add(big_n1));
-        let x2 = I::load(x_p.add(big_n2));
-        let x3 = I::load(x_p.add(big_n3));
-        let x4 = I::load(x_p.add(big_n4));
-        let x5 = I::load(x_p.add(big_n5));
-        let x6 = I::load(x_p.add(big_n6));
-        let x7 = I::load(x_p.add(big_n7));
-
-        let a04 = I::add(x0, x4);
-        let s04 = I::sub(x0, x4);
-        let a26 = I::add(x2, x6);
-        let js26 = I::xpj(fwd, I::sub(x2, x6));
-        let a15 = I::add(x1, x5);
-        let s15 = I::sub(x1, x5);
-        let a37 = I::add(x3, x7);
-        let js37 = I::xpj(fwd, I::sub(x3, x7));
-
-        let a04_p1_a26 = I::add(a04, a26);
-        let s04_mj_s26 = I::sub(s04, js26);
-        let a04_m1_a26 = I::sub(a04, a26);
-        let s04_pj_s26 = I::add(s04, js26);
-        let a15_p1_a37 = I::add(a15, a37);
-        let w8_s15_mj_s37 = I::xw8(fwd, I::sub(s15, js37));
-        let j_a15_m1_a37 = I::xpj(fwd, I::sub(a15, a37));
-        let v8_s15_pj_s37 = I::xv8(fwd, I::add(s15, js37));
-
-        let w1p = I::load(twid(8, big_n, 1, w, p));
-        let w2p = I::load(twid(8, big_n, 2, w, p));
-        let w3p = I::load(twid(8, big_n, 3, w, p));
-        let w4p = I::load(twid(8, big_n, 4, w, p));
-        let w5p = I::load(twid(8, big_n, 5, w, p));
-        let w6p = I::load(twid(8, big_n, 6, w, p));
-        let w7p = I::load(twid(8, big_n, 7, w, p));
-
-        let aa = I::add(a04_p1_a26, a15_p1_a37);
-        let bb = I::mul(w1p, I::add(s04_mj_s26, w8_s15_mj_s37));
-        let cc = I::mul(w2p, I::sub(a04_m1_a26, j_a15_m1_a37));
-        let dd = I::mul(w3p, I::sub(s04_pj_s26, v8_s15_pj_s37));
-        let ee = I::mul(w4p, I::sub(a04_p1_a26, a15_p1_a37));
-        let ff = I::mul(w5p, I::sub(s04_mj_s26, w8_s15_mj_s37));
-        let gg = I::mul(w6p, I::add(a04_m1_a26, j_a15_m1_a37));
-        let hh = I::mul(w7p, I::add(s04_pj_s26, v8_s15_pj_s37));
-
-        {
-            let ab = I::catlo(aa, bb);
-            I::store(y_8p.add(0), ab);
-            let cd = I::catlo(cc, dd);
-            I::store(y_8p.add(2), cd);
-            let ef = I::catlo(ee, ff);
-            I::store(y_8p.add(4), ef);
-            let gh = I::catlo(gg, hh);
-            I::store(y_8p.add(6), gh);
-        }
-        {
-            let ab = I::cathi(aa, bb);
-            I::store(y_8p.add(8), ab);
-            let cd = I::cathi(cc, dd);
-            I::store(y_8p.add(10), cd);
-            let ef = I::cathi(ee, ff);
-            I::store(y_8p.add(12), ef);
-            let gh = I::cathi(gg, hh);
-            I::store(y_8p.add(14), gh);
-        }
-
-        p += 2;
-    }
-}
-
-#[inline(always)]
-#[allow(dead_code)]
-unsafe fn core_x4<I2: FftSimd64X2, I4: FftSimd64X4>(
-    fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
-) {
-    debug_assert_eq!(s, 1);
-    if n == 16 {
-        return core_x2::<I2>(fwd, n, s, x, y, w);
-    }
-
-    let big_n = n;
-    let big_n0 = 0;
-    let big_n1 = big_n / 8;
-    let big_n2 = big_n1 * 2;
-    let big_n3 = big_n1 * 3;
-    let big_n4 = big_n1 * 4;
-    let big_n5 = big_n1 * 5;
-    let big_n6 = big_n1 * 6;
-    let big_n7 = big_n1 * 7;
-
-    debug_assert_eq!(big_n1 % 4, 0);
-    let mut p = 0;
-    while p < big_n1 {
-        let x_p = x.add(p);
-        let y_8p = y.add(8 * p);
-
-        let x0 = I4::load(x_p.add(big_n0));
-        let x1 = I4::load(x_p.add(big_n1));
-        let x2 = I4::load(x_p.add(big_n2));
-        let x3 = I4::load(x_p.add(big_n3));
-        let x4 = I4::load(x_p.add(big_n4));
-        let x5 = I4::load(x_p.add(big_n5));
-        let x6 = I4::load(x_p.add(big_n6));
-        let x7 = I4::load(x_p.add(big_n7));
-
-        let a04 = I4::add(x0, x4);
-        let s04 = I4::sub(x0, x4);
-        let a26 = I4::add(x2, x6);
-        let js26 = I4::xpj(fwd, I4::sub(x2, x6));
-        let a15 = I4::add(x1, x5);
-        let s15 = I4::sub(x1, x5);
-        let a37 = I4::add(x3, x7);
-        let js37 = I4::xpj(fwd, I4::sub(x3, x7));
-
-        let a04_p1_a26 = I4::add(a04, a26);
-        let s04_mj_s26 = I4::sub(s04, js26);
-        let a04_m1_a26 = I4::sub(a04, a26);
-        let s04_pj_s26 = I4::add(s04, js26);
-        let a15_p1_a37 = I4::add(a15, a37);
-        let w8_s15_mj_s37 = I4::xw8(fwd, I4::sub(s15, js37));
-        let j_a15_m1_a37 = I4::xpj(fwd, I4::sub(a15, a37));
-        let v8_s15_pj_s37 = I4::xv8(fwd, I4::add(s15, js37));
-
-        let w1p = I4::load(twid(8, big_n, 1, w, p));
-        let w2p = I4::load(twid(8, big_n, 2, w, p));
-        let w3p = I4::load(twid(8, big_n, 3, w, p));
-        let w4p = I4::load(twid(8, big_n, 4, w, p));
-        let w5p = I4::load(twid(8, big_n, 5, w, p));
-        let w6p = I4::load(twid(8, big_n, 6, w, p));
-        let w7p = I4::load(twid(8, big_n, 7, w, p));
-
-        let a = I4::add(a04_p1_a26, a15_p1_a37);
-        let b = I4::mul(w1p, I4::add(s04_mj_s26, w8_s15_mj_s37));
-        let c = I4::mul(w2p, I4::sub(a04_m1_a26, j_a15_m1_a37));
-        let d = I4::mul(w3p, I4::sub(s04_pj_s26, v8_s15_pj_s37));
-        let e = I4::mul(w4p, I4::sub(a04_p1_a26, a15_p1_a37));
-        let f = I4::mul(w5p, I4::sub(s04_mj_s26, w8_s15_mj_s37));
-        let g = I4::mul(w6p, I4::add(a04_m1_a26, j_a15_m1_a37));
-        let h = I4::mul(w7p, I4::add(s04_pj_s26, v8_s15_pj_s37));
-
-        let (abcd0, abcd1, abcd2, abcd3) = I4::transpose(a, b, c, d);
-        let (efgh0, efgh1, efgh2, efgh3) = I4::transpose(e, f, g, h);
-        I4::store(y_8p.add(0), abcd0);
-        I4::store(y_8p.add(4), efgh0);
-        I4::store(y_8p.add(8), abcd1);
-        I4::store(y_8p.add(12), efgh1);
-        I4::store(y_8p.add(16), abcd2);
-        I4::store(y_8p.add(20), efgh2);
-        I4::store(y_8p.add(24), abcd3);
-        I4::store(y_8p.add(28), efgh3);
-
-        p += 4;
-    }
-}
-
-#[inline(always)]
-pub(crate) unsafe fn end_8<I: FftSimd64>(
-    fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    eo: bool,
-) {
-    debug_assert_eq!(n, 8);
-    debug_assert_eq!(s % I::COMPLEX_PER_REG, 0);
-
-    let z = if eo { y } else { x };
-
-    let mut q = 0;
-    while q < s {
-        let xq = x.add(q);
-        let zq = z.add(q);
-
-        let x0 = I::load(xq.add(s * 0));
-        let x1 = I::load(xq.add(s * 1));
-        let x2 = I::load(xq.add(s * 2));
-        let x3 = I::load(xq.add(s * 3));
-        let x4 = I::load(xq.add(s * 4));
-        let x5 = I::load(xq.add(s * 5));
-        let x6 = I::load(xq.add(s * 6));
-        let x7 = I::load(xq.add(s * 7));
-
-        let a04 = I::add(x0, x4);
-        let s04 = I::sub(x0, x4);
-        let a26 = I::add(x2, x6);
-        let js26 = I::xpj(fwd, I::sub(x2, x6));
-        let a15 = I::add(x1, x5);
-        let s15 = I::sub(x1, x5);
-        let a37 = I::add(x3, x7);
-        let js37 = I::xpj(fwd, I::sub(x3, x7));
-
-        let a04_p1_a26 = I::add(a04, a26);
-        let s04_mj_s26 = I::sub(s04, js26);
-        let a04_m1_a26 = I::sub(a04, a26);
-        let s04_pj_s26 = I::add(s04, js26);
-        let a15_p1_a37 = I::add(a15, a37);
-        let w8_s15_mj_s37 = I::xw8(fwd, I::sub(s15, js37));
-        let j_a15_m1_a37 = I::xpj(fwd, I::sub(a15, a37));
-        let v8_s15_pj_s37 = I::xv8(fwd, I::add(s15, js37));
-
-        I::store(zq.add(0), I::add(a04_p1_a26, a15_p1_a37));
-        I::store(zq.add(s), I::add(s04_mj_s26, w8_s15_mj_s37));
-        I::store(zq.add(s * 2), I::sub(a04_m1_a26, j_a15_m1_a37));
-        I::store(zq.add(s * 3), I::sub(s04_pj_s26, v8_s15_pj_s37));
-        I::store(zq.add(s * 4), I::sub(a04_p1_a26, a15_p1_a37));
-        I::store(zq.add(s * 5), I::sub(s04_mj_s26, w8_s15_mj_s37));
-        I::store(zq.add(s * 6), I::add(a04_m1_a26, j_a15_m1_a37));
-        I::store(zq.add(s * 7), I::add(s04_pj_s26, v8_s15_pj_s37));
-
-        q += I::COMPLEX_PER_REG;
-    }
-}
-
-macro_rules! dif8_impl {
+pub fn split_8<T>(slice: &[T]) -> (&[T], &[T], &[T], &[T], &[T], &[T], &[T], &[T]) {
+    let (slice0123, slice4567) = split_2(slice);
+    let (slice0, slice1, slice2, slice3) = split_4(slice0123);
+    let (slice4, slice5, slice6, slice7) = split_4(slice4567);
     (
-        $(
-            $(#[$attr: meta])*
-            pub static $fft: ident = Fft {
-                core_1: $core1______: expr,
-                native: $xn: ty,
-                x1: $x1: ty,
-                $(target: $target: tt,)?
-            };
-        )*
-    ) => {
-        $(
-            #[allow(missing_copy_implementations)]
-            #[allow(non_camel_case_types)]
-            #[allow(dead_code)]
-            $(#[$attr])*
-            struct $fft {
-                __private: (),
-            }
-            #[allow(unused_variables)]
-            #[allow(dead_code)]
-            $(#[$attr])*
-            impl $fft {
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_00<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {}
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_01<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$x1>(FWD, 1 << 1, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_02<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$x1>(FWD, 1 << 2, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_03<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_8::<$x1>(FWD, 1 << 3, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_04<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 4, 1 << 0, x, y, w);
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 3, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_05<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 5, 1 << 0, x, y, w);
-                    end_4::<$xn>(FWD, 1 << 2, 1 << 3, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_06<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 6, 1 << 0, x, y, w);
-                    end_8::<$xn>(FWD, 1 << 3, 1 << 3, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_07<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 7, 1 << 0, x, y, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 3, y, x, w);
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 6, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_08<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 8, 1 << 0, x, y, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 3, y, x, w);
-                    end_4::<$xn>(FWD, 1 << 2, 1 << 6, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_09<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 9, 1 << 0, x, y, w);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 3, y, x, w);
-                    end_8::<$xn>(FWD, 1 << 3, 1 << 6, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_10<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 10, 1 << 0, x, y, w);
-                    core_::<$xn>(FWD, 1 << 07, 1 << 3, y, x, w);
-                    core_::<$xn>(FWD, 1 << 04, 1 << 6, x, y, w);
-                    end_2::<$xn>(FWD, 1 << 01, 1 << 9, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_11<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 11, 1 << 00, x, y, w);
-                    core_::<$xn>(FWD, 1 << 08, 1 << 03, y, x, w);
-                    core_::<$xn>(FWD, 1 << 05, 1 << 06, x, y, w);
-                    end_4::<$xn>(FWD, 1 << 02, 1 << 09, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_12<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 12, 1 << 00, x, y, w);
-                    core_::<$xn>(FWD, 1 << 09, 1 << 03, y, x, w);
-                    core_::<$xn>(FWD, 1 << 06, 1 << 06, x, y, w);
-                    end_8::<$xn>(FWD, 1 << 03, 1 << 09, y, x, true);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_13<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 13, 1 << 00, x, y, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 03, y, x, w);
-                    core_::<$xn>(FWD, 1 << 07, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 04, 1 << 09, y, x, w);
-                    end_2::<$xn>(FWD, 1 << 01, 1 << 12, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_14<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 14, 1 << 00, x, y, w);
-                    core_::<$xn>(FWD, 1 << 11, 1 << 03, y, x, w);
-                    core_::<$xn>(FWD, 1 << 08, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 05, 1 << 09, y, x, w);
-                    end_4::<$xn>(FWD, 1 << 02, 1 << 12, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_15<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 15, 1 << 00, x, y, w);
-                    core_::<$xn>(FWD, 1 << 12, 1 << 03, y, x, w);
-                    core_::<$xn>(FWD, 1 << 09, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 06, 1 << 09, y, x, w);
-                    end_8::<$xn>(FWD, 1 << 03, 1 << 12, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_16<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    $core1______(FWD, 1 << 16, 1 << 00, x, y, w);
-                    core_::<$xn>(FWD, 1 << 13, 1 << 03, y, x, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 07, 1 << 09, y, x, w);
-                    core_::<$xn>(FWD, 1 << 04, 1 << 12, x, y, w);
-                    end_2::<$xn>(FWD, 1 << 01, 1 << 15, y, x, true);
-                }
-            }
-            $(#[$attr])*
-            pub(crate) static $fft: crate::FftImpl = crate::FftImpl {
-                fwd: [
-                    <$fft>::fft_00::<true>,
-                    <$fft>::fft_01::<true>,
-                    <$fft>::fft_02::<true>,
-                    <$fft>::fft_03::<true>,
-                    <$fft>::fft_04::<true>,
-                    <$fft>::fft_05::<true>,
-                    <$fft>::fft_06::<true>,
-                    <$fft>::fft_07::<true>,
-                    <$fft>::fft_08::<true>,
-                    <$fft>::fft_09::<true>,
-                    <$fft>::fft_10::<true>,
-                    <$fft>::fft_11::<true>,
-                    <$fft>::fft_12::<true>,
-                    <$fft>::fft_13::<true>,
-                    <$fft>::fft_14::<true>,
-                    <$fft>::fft_15::<true>,
-                    <$fft>::fft_16::<true>,
-                ],
-                inv: [
-                    <$fft>::fft_00::<false>,
-                    <$fft>::fft_01::<false>,
-                    <$fft>::fft_02::<false>,
-                    <$fft>::fft_03::<false>,
-                    <$fft>::fft_04::<false>,
-                    <$fft>::fft_05::<false>,
-                    <$fft>::fft_06::<false>,
-                    <$fft>::fft_07::<false>,
-                    <$fft>::fft_08::<false>,
-                    <$fft>::fft_09::<false>,
-                    <$fft>::fft_10::<false>,
-                    <$fft>::fft_11::<false>,
-                    <$fft>::fft_12::<false>,
-                    <$fft>::fft_13::<false>,
-                    <$fft>::fft_14::<false>,
-                    <$fft>::fft_15::<false>,
-                    <$fft>::fft_16::<false>,
-                ],
-            };
-            )*
-    };
+        slice0, slice1, slice2, slice3, slice4, slice5, slice6, slice7,
+    )
+}
+#[inline(always)]
+pub fn split_mut_8<T>(
+    slice: &mut [T],
+) -> (
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+    &mut [T],
+) {
+    let (slice0123, slice4567) = split_mut_2(slice);
+    let (slice0, slice1, slice2, slice3) = split_mut_4(slice0123);
+    let (slice4, slice5, slice6, slice7) = split_mut_4(slice4567);
+    (
+        slice0, slice1, slice2, slice3, slice4, slice5, slice6, slice7,
+    )
 }
 
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-use crate::x86::*;
+#[inline(always)]
+fn stockham_core_1x2<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    s: usize,
+    x: &[c64xN],
+    y: &mut [c64xN],
+    w_init: &[c64xN],
+    _w: &[c64],
+) {
+    assert_eq!(s, 1);
 
-dif8_impl! {
-    pub static DIF8_SCALAR = Fft {
-        core_1: core_::<Scalar>,
-        native: Scalar,
-        x1: Scalar,
-    };
+    let y = pulp::as_arrays_mut::<8, _>(y).0;
+    let (x0, x1, x2, x3, x4, x5, x6, x7) = split_8(x);
+    let (_, w1, w2, w3, w4, w5, w6, w7) = split_8(w_init);
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub static DIF8_AVX = Fft {
-        core_1: core_x2::<AvxX2>,
-        native: AvxX2,
-        x1: AvxX1,
-        target: "avx",
-    };
+    for ((x0, x1, x2, x3, x4, x5, x6, x7), y, (w1, w2, w3, w4, w5, w6, w7)) in izip!(
+        izip!(x0, x1, x2, x3, x4, x5, x6, x7),
+        y,
+        izip!(w1, w2, w3, w4, w5, w6, w7),
+    ) {
+        let x0 = *x0;
+        let x1 = *x1;
+        let x2 = *x2;
+        let x3 = *x3;
+        let x4 = *x4;
+        let x5 = *x5;
+        let x6 = *x6;
+        let x7 = *x7;
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub static DIF8_FMA = Fft {
-        core_1: core_x2::<FmaX2>,
-        native: FmaX2,
-        x1: FmaX1,
-        target: "fma",
-    };
+        let a04 = simd.add(x0, x4);
+        let s04 = simd.sub(x0, x4);
+        let a26 = simd.add(x2, x6);
+        let js26 = simd.mul_j(fwd, simd.sub(x2, x6));
+        let a15 = simd.add(x1, x5);
+        let s15 = simd.sub(x1, x5);
+        let a37 = simd.add(x3, x7);
+        let js37 = simd.mul_j(fwd, simd.sub(x3, x7));
 
-    #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
-    pub static DIF8_AVX512 = Fft {
-        core_1: core_x4::<Avx512X2, Avx512X4>,
-        native: Avx512X4,
-        x1: Avx512X1,
-        target: "avx512f",
-    };
+        let a04_p1_a26 = simd.add(a04, a26);
+        let s04_mj_s26 = simd.sub(s04, js26);
+        let a04_m1_a26 = simd.sub(a04, a26);
+        let s04_pj_s26 = simd.add(s04, js26);
+        let a15_p1_a37 = simd.add(a15, a37);
+        let w8_s15_mj_s37 = simd.mul_exp_neg_pi_over_8(fwd, simd.sub(s15, js37));
+        let j_a15_m1_a37 = simd.mul_j(fwd, simd.sub(a15, a37));
+        let v8_s15_pj_s37 = simd.mul_exp_pi_over_8(fwd, simd.add(s15, js37));
+
+        let w1 = *w1;
+        let w2 = *w2;
+        let w3 = *w3;
+        let w4 = *w4;
+        let w5 = *w5;
+        let w6 = *w6;
+        let w7 = *w7;
+
+        let aa = simd.add(a04_p1_a26, a15_p1_a37);
+        let bb = simd.mul(w1, simd.add(s04_mj_s26, w8_s15_mj_s37));
+        let cc = simd.mul(w2, simd.sub(a04_m1_a26, j_a15_m1_a37));
+        let dd = simd.mul(w3, simd.sub(s04_pj_s26, v8_s15_pj_s37));
+        let ee = simd.mul(w4, simd.sub(a04_p1_a26, a15_p1_a37));
+        let ff = simd.mul(w5, simd.sub(s04_mj_s26, w8_s15_mj_s37));
+        let gg = simd.mul(w6, simd.add(a04_m1_a26, j_a15_m1_a37));
+        let hh = simd.mul(w7, simd.add(s04_pj_s26, v8_s15_pj_s37));
+
+        let ab = simd.catlo(aa, bb);
+        y[0] = ab;
+        let cd = simd.catlo(cc, dd);
+        y[1] = cd;
+        let ef = simd.catlo(ee, ff);
+        y[2] = ef;
+        let gh = simd.catlo(gg, hh);
+        y[3] = gh;
+
+        let ab = simd.cathi(aa, bb);
+        y[4] = ab;
+        let cd = simd.cathi(cc, dd);
+        y[5] = cd;
+        let ef = simd.cathi(ee, ff);
+        y[6] = ef;
+        let gh = simd.cathi(gg, hh);
+        y[7] = gh;
+    }
 }
 
-pub(crate) fn runtime_fft() -> crate::FftImpl {
-    #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
-    if x86_feature_detected!("avx512f") {
-        return DIF8_AVX512;
-    }
+#[inline(always)]
+fn stockham_core_1x4<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    s: usize,
+    x: &[c64xN],
+    y: &mut [c64xN],
+    w_init: &[c64xN],
+    _w: &[c64],
+) {
+    assert_eq!(s, 1);
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    if x86_feature_detected!("fma") {
-        return DIF8_FMA;
-    } else if x86_feature_detected!("avx") {
-        return DIF8_AVX;
-    }
+    let y = pulp::as_arrays_mut::<8, _>(y).0;
+    let (x0, x1, x2, x3, x4, x5, x6, x7) = split_8(x);
+    let (_, w1, w2, w3, w4, w5, w6, w7) = split_8(w_init);
 
-    DIF8_SCALAR
+    for ((x0, x1, x2, x3, x4, x5, x6, x7), y, (w1, w2, w3, w4, w5, w6, w7)) in izip!(
+        izip!(x0, x1, x2, x3, x4, x5, x6, x7),
+        y,
+        izip!(w1, w2, w3, w4, w5, w6, w7),
+    ) {
+        let x0 = *x0;
+        let x1 = *x1;
+        let x2 = *x2;
+        let x3 = *x3;
+        let x4 = *x4;
+        let x5 = *x5;
+        let x6 = *x6;
+        let x7 = *x7;
+
+        let a04 = simd.add(x0, x4);
+        let s04 = simd.sub(x0, x4);
+        let a26 = simd.add(x2, x6);
+        let js26 = simd.mul_j(fwd, simd.sub(x2, x6));
+        let a15 = simd.add(x1, x5);
+        let s15 = simd.sub(x1, x5);
+        let a37 = simd.add(x3, x7);
+        let js37 = simd.mul_j(fwd, simd.sub(x3, x7));
+
+        let a04_p1_a26 = simd.add(a04, a26);
+        let s04_mj_s26 = simd.sub(s04, js26);
+        let a04_m1_a26 = simd.sub(a04, a26);
+        let s04_pj_s26 = simd.add(s04, js26);
+        let a15_p1_a37 = simd.add(a15, a37);
+        let w8_s15_mj_s37 = simd.mul_exp_neg_pi_over_8(fwd, simd.sub(s15, js37));
+        let j_a15_m1_a37 = simd.mul_j(fwd, simd.sub(a15, a37));
+        let v8_s15_pj_s37 = simd.mul_exp_pi_over_8(fwd, simd.add(s15, js37));
+
+        let w1 = *w1;
+        let w2 = *w2;
+        let w3 = *w3;
+        let w4 = *w4;
+        let w5 = *w5;
+        let w6 = *w6;
+        let w7 = *w7;
+
+        let a = simd.add(a04_p1_a26, a15_p1_a37);
+        let b = simd.mul(w1, simd.add(s04_mj_s26, w8_s15_mj_s37));
+        let c = simd.mul(w2, simd.sub(a04_m1_a26, j_a15_m1_a37));
+        let d = simd.mul(w3, simd.sub(s04_pj_s26, v8_s15_pj_s37));
+        let e = simd.mul(w4, simd.sub(a04_p1_a26, a15_p1_a37));
+        let f = simd.mul(w5, simd.sub(s04_mj_s26, w8_s15_mj_s37));
+        let g = simd.mul(w6, simd.add(a04_m1_a26, j_a15_m1_a37));
+        let h = simd.mul(w7, simd.add(s04_pj_s26, v8_s15_pj_s37));
+
+        let (abcd0, abcd1, abcd2, abcd3) = simd.transpose(a, b, c, d);
+        let (efgh0, efgh1, efgh2, efgh3) = simd.transpose(e, f, g, h);
+
+        y[0] = abcd0;
+        y[1] = efgh0;
+        y[2] = abcd1;
+        y[3] = efgh1;
+        y[4] = abcd2;
+        y[5] = efgh2;
+        y[6] = abcd3;
+        y[7] = efgh3;
+    }
+}
+
+#[inline(always)]
+fn stockham_core_generic<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    s: usize,
+    x: &[c64xN],
+    y: &mut [c64xN],
+    _w_init: &[c64xN],
+    w: &[c64],
+) {
+    assert_eq!(s % simd.lane_count(), 0);
+    let simd_s = s / simd.lane_count();
+
+    let w = pulp::as_arrays::<8, _>(w).0;
+
+    let (x0, x1, x2, x3, x4, x5, x6, x7) = split_8(x);
+
+    for (x0, x1, x2, x3, x4, x5, x6, x7, y, w) in izip!(
+        x0.chunks_exact(simd_s),
+        x1.chunks_exact(simd_s),
+        x2.chunks_exact(simd_s),
+        x3.chunks_exact(simd_s),
+        x4.chunks_exact(simd_s),
+        x5.chunks_exact(simd_s),
+        x6.chunks_exact(simd_s),
+        x7.chunks_exact(simd_s),
+        y.chunks_exact_mut(8 * simd_s),
+        w.chunks_exact(s),
+    ) {
+        let [_, w1, w2, w3, w4, w5, w6, w7] = w[0];
+
+        let w1 = simd.splat(w1);
+        let w2 = simd.splat(w2);
+        let w3 = simd.splat(w3);
+        let w4 = simd.splat(w4);
+        let w5 = simd.splat(w5);
+        let w6 = simd.splat(w6);
+        let w7 = simd.splat(w7);
+
+        let (y0, y1, y2, y3, y4, y5, y6, y7) = split_mut_8(y);
+
+        for ((x0, x1, x2, x3, x4, x5, x6, x7), (y0, y1, y2, y3, y4, y5, y6, y7)) in izip!(
+            izip!(x0, x1, x2, x3, x4, x5, x6, x7),
+            izip!(y0, y1, y2, y3, y4, y5, y6, y7),
+        ) {
+            let x0 = *x0;
+            let x1 = *x1;
+            let x2 = *x2;
+            let x3 = *x3;
+            let x4 = *x4;
+            let x5 = *x5;
+            let x6 = *x6;
+            let x7 = *x7;
+
+            let a04 = simd.add(x0, x4);
+            let s04 = simd.sub(x0, x4);
+            let a26 = simd.add(x2, x6);
+            let js26 = simd.mul_j(fwd, simd.sub(x2, x6));
+            let a15 = simd.add(x1, x5);
+            let s15 = simd.sub(x1, x5);
+            let a37 = simd.add(x3, x7);
+            let js37 = simd.mul_j(fwd, simd.sub(x3, x7));
+            let a04_p1_a26 = simd.add(a04, a26);
+            let s04_mj_s26 = simd.sub(s04, js26);
+            let a04_m1_a26 = simd.sub(a04, a26);
+            let s04_pj_s26 = simd.add(s04, js26);
+            let a15_p1_a37 = simd.add(a15, a37);
+            let w8_s15_mj_s37 = simd.mul_exp_neg_pi_over_8(fwd, simd.sub(s15, js37));
+            let j_a15_m1_a37 = simd.mul_j(fwd, simd.sub(a15, a37));
+            let v8_s15_pj_s37 = simd.mul_exp_pi_over_8(fwd, simd.add(s15, js37));
+
+            *y0 = simd.add(a04_p1_a26, a15_p1_a37);
+            *y1 = simd.mul(w1, simd.add(s04_mj_s26, w8_s15_mj_s37));
+            *y2 = simd.mul(w2, simd.sub(a04_m1_a26, j_a15_m1_a37));
+            *y3 = simd.mul(w3, simd.sub(s04_pj_s26, v8_s15_pj_s37));
+            *y4 = simd.mul(w4, simd.sub(a04_p1_a26, a15_p1_a37));
+            *y5 = simd.mul(w5, simd.sub(s04_mj_s26, w8_s15_mj_s37));
+            *y6 = simd.mul(w6, simd.add(a04_m1_a26, j_a15_m1_a37));
+            *y7 = simd.mul(w7, simd.add(s04_pj_s26, v8_s15_pj_s37));
+        }
+    }
+}
+
+#[inline(always)]
+fn stockham_core<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    s: usize,
+    x: &[c64xN],
+    y: &mut [c64xN],
+    w_init: &[c64xN],
+    w: &[c64],
+) {
+    // we create a fn pointer that will be force-inlined in release builds
+    // but not in debug builds. this helps keep compile times low, since dead code
+    // elimination handles this well in release builds. and the function pointer indirection
+    // prevents inlining in debug builds.
+    let stockham = if s == 1 && simd.lane_count() == 2 {
+        stockham_core_1x2
+    } else if s == 1 && simd.lane_count() == 4 {
+        stockham_core_1x4
+    } else {
+        stockham_core_generic
+    };
+    stockham(simd, fwd, s, x, y, w_init, w);
+}
+
+#[inline(always)]
+fn last_butterfly<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    x0: c64xN,
+    x1: c64xN,
+    x2: c64xN,
+    x3: c64xN,
+    x4: c64xN,
+    x5: c64xN,
+    x6: c64xN,
+    x7: c64xN,
+) -> (c64xN, c64xN, c64xN, c64xN, c64xN, c64xN, c64xN, c64xN) {
+    let a04 = simd.add(x0, x4);
+    let s04 = simd.sub(x0, x4);
+    let a26 = simd.add(x2, x6);
+    let js26 = simd.mul_j(fwd, simd.sub(x2, x6));
+    let a15 = simd.add(x1, x5);
+    let s15 = simd.sub(x1, x5);
+    let a37 = simd.add(x3, x7);
+    let js37 = simd.mul_j(fwd, simd.sub(x3, x7));
+
+    let a04_p1_a26 = simd.add(a04, a26);
+    let s04_mj_s26 = simd.sub(s04, js26);
+    let a04_m1_a26 = simd.sub(a04, a26);
+    let s04_pj_s26 = simd.add(s04, js26);
+    let a15_p1_a37 = simd.add(a15, a37);
+    let w8_s15_mj_s37 = simd.mul_exp_neg_pi_over_8(fwd, simd.sub(s15, js37));
+    let j_a15_m1_a37 = simd.mul_j(fwd, simd.sub(a15, a37));
+    let v8_s15_pj_s37 = simd.mul_exp_pi_over_8(fwd, simd.add(s15, js37));
+
+    (
+        simd.add(a04_p1_a26, a15_p1_a37),
+        simd.add(s04_mj_s26, w8_s15_mj_s37),
+        simd.sub(a04_m1_a26, j_a15_m1_a37),
+        simd.sub(s04_pj_s26, v8_s15_pj_s37),
+        simd.sub(a04_p1_a26, a15_p1_a37),
+        simd.sub(s04_mj_s26, w8_s15_mj_s37),
+        simd.add(a04_m1_a26, j_a15_m1_a37),
+        simd.add(s04_pj_s26, v8_s15_pj_s37),
+    )
+}
+
+#[inline(always)]
+pub fn stockham_dif8_end<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    write_to_x: bool,
+    s: usize,
+    x: &mut [c64xN],
+    y: &mut [c64xN],
+) {
+    assert_eq!(s % simd.lane_count(), 0);
+    let (x0, x1, x2, x3, x4, x5, x6, x7) = split_mut_8(x);
+    let (y0, y1, y2, y3, y4, y5, y6, y7) = split_mut_8(y);
+
+    // we create a fn pointer that will be force-inlined in release builds
+    // but not in debug builds. this helps keep compile times low, since dead code
+    // elimination handles this well in release builds. and the function pointer indirection
+    // prevents inlining in debug builds.
+    let last_butterfly: fn(_, _, _, _, _, _, _, _, _, _) -> _ = last_butterfly;
+
+    if write_to_x {
+        for (x0, x1, x2, x3, x4, x5, x6, x7) in izip!(x0, x1, x2, x3, x4, x5, x6, x7) {
+            (*x0, *x1, *x2, *x3, *x4, *x5, *x6, *x7) =
+                last_butterfly(simd, fwd, *x0, *x1, *x2, *x3, *x4, *x5, *x6, *x7);
+        }
+    } else {
+        for ((x0, x1, x2, x3, x4, x5, x6, x7), (y0, y1, y2, y3, y4, y5, y6, y7)) in izip!(
+            izip!(x0, x1, x2, x3, x4, x5, x6, x7),
+            izip!(y0, y1, y2, y3, y4, y5, y6, y7),
+        ) {
+            (*y0, *y1, *y2, *y3, *y4, *y5, *y6, *y7) =
+                last_butterfly(simd, fwd, *x0, *x1, *x2, *x3, *x4, *x5, *x6, *x7);
+        }
+    }
+}
+
+struct Dif8<N: nat::Nat>(N);
+impl<N: nat::Nat> nat::Nat for Dif8<N> {
+    const VALUE: usize = N::VALUE;
+}
+
+// size 2
+impl RecursiveFft for Dif8<nat::N0> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        write_to_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        crate::dif2::stockham_dif2_end(simd, fwd, write_to_x, s, x, y);
+    }
+}
+
+// size 4
+impl RecursiveFft for Dif8<nat::N1> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        write_to_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        crate::dif4::stockham_dif4_end(simd, fwd, write_to_x, s, x, y);
+    }
+}
+
+// size 8
+impl RecursiveFft for Dif8<nat::N2> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        write_to_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        stockham_dif8_end(simd, fwd, write_to_x, s, x, y);
+    }
+}
+
+impl<N: nat::Nat> RecursiveFft for Dif8<nat::Plus3<N>>
+where
+    Dif8<N>: RecursiveFft,
+{
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        write_to_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        w_init: &[c64xN],
+        w: &[c64],
+    ) {
+        stockham_core(simd, fwd, s, x, y, w_init, w);
+        Dif8::<N>::fft_recurse_impl(simd, fwd, !write_to_x, s * 8, y, x, w_init, w);
+    }
+}
+
+pub(crate) fn fft_impl<c64xN: Pod>(simd: impl FftSimd<c64xN>) -> crate::FftImpl {
+    let fwd = [
+        fn_ptr::<true, Dif8<nat::N0>, _, _>(simd),
+        fn_ptr::<true, Dif8<nat::N1>, _, _>(simd),
+        fn_ptr::<true, Dif8<nat::N2>, _, _>(simd),
+        fn_ptr::<true, Dif8<nat::N3>, _, _>(simd),
+        fn_ptr::<true, Dif8<nat::N4>, _, _>(simd),
+        fn_ptr::<true, Dif8<nat::N5>, _, _>(simd),
+        fn_ptr::<true, Dif8<nat::N6>, _, _>(simd),
+        fn_ptr::<true, Dif8<nat::N7>, _, _>(simd),
+        fn_ptr::<true, Dif8<nat::N8>, _, _>(simd),
+        fn_ptr::<true, Dif8<nat::N9>, _, _>(simd),
+    ];
+    let inv = [
+        fn_ptr::<false, Dif8<nat::N0>, _, _>(simd),
+        fn_ptr::<false, Dif8<nat::N1>, _, _>(simd),
+        fn_ptr::<false, Dif8<nat::N2>, _, _>(simd),
+        fn_ptr::<false, Dif8<nat::N3>, _, _>(simd),
+        fn_ptr::<false, Dif8<nat::N4>, _, _>(simd),
+        fn_ptr::<false, Dif8<nat::N5>, _, _>(simd),
+        fn_ptr::<false, Dif8<nat::N6>, _, _>(simd),
+        fn_ptr::<false, Dif8<nat::N7>, _, _>(simd),
+        fn_ptr::<false, Dif8<nat::N8>, _, _>(simd),
+        fn_ptr::<false, Dif8<nat::N9>, _, _>(simd),
+    ];
+    crate::FftImpl { fwd, inv }
+}
+
+pub fn fft_impl_dispatch(n: usize) -> [fn(&mut [c64], &mut [c64], &[c64], &[c64]); 2] {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        #[cfg(feature = "nightly")]
+        if let Some(simd) = pulp::x86::V4::try_new() {
+            if n >= 8 * simd.lane_count() {
+                return fft_impl(simd).make_fn_ptr(n);
+            }
+        }
+        if let Some(simd) = pulp::x86::V3::try_new() {
+            if n >= 8 * simd.lane_count() {
+                return fft_impl(simd).make_fn_ptr(n);
+            }
+        }
+    }
+    fft_impl(crate::fft_simd::Scalar).make_fn_ptr(n)
 }

--- a/src/dit2.rs
+++ b/src/dit2.rs
@@ -1,418 +1,209 @@
-// Copyright (c) 2019 OK Ojisan(Takuya OKAHISA)
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy of
-// this software and associated documentation files (the "Software"), to deal in
-// the Software without restriction, including without limitation the rights to
-// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-// of the Software, and to permit persons to whom the Software is furnished to do
-// so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
-use crate::c64;
-use crate::fft_simd::{twid, twid_t, FftSimd64, FftSimd64X2, Scalar};
-use crate::x86_feature_detected;
+use crate::{
+    c64,
+    dif2::{split_2, split_mut_2},
+    fft_simd::{FftSimd, Pod},
+    fn_ptr, nat, RecursiveFft,
+};
 
 #[inline(always)]
-unsafe fn core_<I: FftSimd64>(
+fn stockham_core_1x2<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
     _fwd: bool,
-    n: usize,
     s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
+    x: &mut [c64xN],
+    y: &[c64xN],
+    w_init: &[c64xN],
+    _w: &[c64],
 ) {
-    debug_assert_eq!(s % I::COMPLEX_PER_REG, 0);
+    assert_eq!(s, 1);
 
-    let m = n / 2;
-    let big_n = n * s;
-    let big_n0 = 0;
-    let big_n1 = big_n / 2;
+    let y = pulp::as_arrays::<2, _>(y).0;
+    let (x0, x1) = split_mut_2(x);
+    let (_, w1) = split_2(w_init);
 
-    for p in 0..m {
-        let sp = s * p;
-        let s2p = 2 * sp;
-        let w1p = I::splat(twid_t(2, big_n, 1, w, sp));
+    for (y, x0, x1, w1) in izip!(y, x0, x1, w1) {
+        let ab0 = y[0];
+        let ab1 = y[1];
+        let w1 = *w1;
 
-        let mut q = 0;
-        while q < s {
-            let xq_sp = x.add(q + sp);
-            let yq_s2p = y.add(q + s2p);
+        let a = simd.catlo(ab0, ab1);
+        let b = simd.mul(w1, simd.cathi(ab0, ab1));
 
-            let a = I::load(yq_s2p.add(s * 0));
-            let b = I::mul(w1p, I::load(yq_s2p.add(s * 1)));
+        *x0 = simd.add(a, b);
+        *x1 = simd.sub(a, b);
+    }
+}
 
-            I::store(xq_sp.add(big_n0), I::add(a, b));
-            I::store(xq_sp.add(big_n1), I::sub(a, b));
+#[inline(always)]
+fn stockham_core_generic<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    _fwd: bool,
+    s: usize,
+    x: &mut [c64xN],
+    y: &[c64xN],
+    _w_init: &[c64xN],
+    w: &[c64],
+) {
+    assert_eq!(s % simd.lane_count(), 0);
+    let simd_s = s / simd.lane_count();
 
-            q += I::COMPLEX_PER_REG;
+    let w = pulp::as_arrays::<2, _>(w).0;
+
+    let (x0, x1) = split_mut_2(x);
+    for (x0, x1, y, w) in izip!(
+        x0.chunks_exact_mut(simd_s),
+        x1.chunks_exact_mut(simd_s),
+        y.chunks_exact(2 * simd_s),
+        w.chunks_exact(s),
+    ) {
+        let [_, w1] = w[0];
+
+        let w1 = simd.splat(w1);
+
+        let (y0, y1) = split_2(y);
+
+        for (x0, x1, y0, y1) in izip!(x0, x1, y0, y1) {
+            let a = *y0;
+            let b = simd.mul(w1, *y1);
+
+            *x0 = simd.add(a, b);
+            *x1 = simd.sub(a, b);
         }
     }
 }
 
 #[inline(always)]
-#[allow(dead_code)]
-unsafe fn core_x2<I: FftSimd64X2>(
-    _fwd: bool,
-    n: usize,
+fn stockham_core<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
     s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
+    x: &mut [c64xN],
+    y: &[c64xN],
+    w_init: &[c64xN],
+    w: &[c64],
 ) {
-    debug_assert_eq!(s, 1);
-
-    let big_n = n;
-    let big_n0 = 0;
-    let big_n1 = big_n / 2;
-
-    let mut p = 0;
-    while p < big_n1 {
-        let x_p = x.add(p);
-        let y_2p = y.add(2 * p);
-
-        let w1p = I::load(twid(2, big_n, 1, w, p));
-
-        let ab0 = I::load(y_2p.add(0));
-        let ab1 = I::load(y_2p.add(2));
-
-        let a = I::catlo(ab0, ab1);
-        let b = I::mul(w1p, I::cathi(ab0, ab1));
-
-        I::store(x_p.add(big_n0), I::add(a, b));
-        I::store(x_p.add(big_n1), I::sub(a, b));
-
-        p += 2;
-    }
+    // we create a fn pointer that will be force-inlined in release builds
+    // but not in debug builds. this helps keep compile times low, since dead code
+    // elimination handles this well in release builds. and the function pointer indirection
+    // prevents inlining in debug builds.
+    let stockham = if s == 1 && simd.lane_count() == 2 {
+        stockham_core_1x2
+    } else {
+        stockham_core_generic
+    };
+    stockham(simd, fwd, s, x, y, w_init, w);
 }
 
 #[inline(always)]
-pub unsafe fn end_2<I: FftSimd64>(
+fn last_butterfly<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
     _fwd: bool,
-    n: usize,
+    x0: c64xN,
+    x1: c64xN,
+) -> (c64xN, c64xN) {
+    (simd.add(x0, x1), simd.sub(x0, x1))
+}
+
+#[inline(always)]
+pub fn stockham_dit2_end<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    read_from_x: bool,
     s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    eo: bool,
+    x: &mut [c64xN],
+    y: &mut [c64xN],
 ) {
-    debug_assert_eq!(n, 2);
-    debug_assert_eq!(s % I::COMPLEX_PER_REG, 0);
-    let z = if eo { y } else { x };
+    assert_eq!(s % simd.lane_count(), 0);
+    let (x0, x1) = split_mut_2(x);
+    let (y0, y1) = split_mut_2(y);
 
-    let mut q = 0;
-    while q < s {
-        let xq = x.add(q);
-        let zq = z.add(q);
+    // we create a fn pointer that will be force-inlined in release builds
+    // but not in debug builds. this helps keep compile times low, since dead code
+    // elimination handles this well in release builds. and the function pointer indirection
+    // prevents inlining in debug builds.
+    let last_butterfly: fn(_, _, _, _) -> _ = last_butterfly;
 
-        let a = I::load(zq.add(0));
-        let b = I::load(zq.add(s));
-
-        I::store(xq.add(0), I::add(a, b));
-        I::store(xq.add(s), I::sub(a, b));
-
-        q += I::COMPLEX_PER_REG;
+    if read_from_x {
+        for (x0, x1) in izip!(x0, x1) {
+            (*x0, *x1) = last_butterfly(simd, fwd, *x0, *x1);
+        }
+    } else {
+        for (x0, x1, y0, y1) in izip!(x0, x1, y0, y1) {
+            (*x0, *x1) = last_butterfly(simd, fwd, *y0, *y1);
+        }
     }
 }
 
-macro_rules! dit2_impl {
-    (
-        $(
-            $(#[$attr: meta])*
-            pub static $fft: ident = Fft {
-                core_1: $core1______: expr,
-                native: $xn: ty,
-                x1: $x1: ty,
-                $(target: $target: tt,)?
-            };
-        )*
-    ) => {
-        $(
-            #[allow(missing_copy_implementations)]
-            #[allow(non_camel_case_types)]
-            #[allow(dead_code)]
-            $(#[$attr])*
-            struct $fft {
-                __private: (),
-            }
-            #[allow(unused_variables)]
-            #[allow(dead_code)]
-            $(#[$attr])*
-            impl $fft {
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_00<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {}
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_01<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$x1>(FWD, 1 << 1, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_02<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 1, y, x, true);
-                    $core1______(FWD, 1 << 2, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_03<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 2, x, y, false);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 1, y, x, w);
-                    $core1______(FWD, 1 << 3, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_04<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 3, y, x, true);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 2, x, y, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 1, y, x, w);
-                    $core1______(FWD, 1 << 4, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_05<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 4, x, y, false);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 3, y, x, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 2, x, y, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 1, y, x, w);
-                    $core1______(FWD, 1 << 5, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_06<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 5, y, x, true);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 4, x, y, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 3, y, x, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 2, x, y, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 1, y, x, w);
-                    $core1______(FWD, 1 << 6, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_07<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 6, x, y, false);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 5, y, x, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 4, x, y, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 3, y, x, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 2, x, y, w);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 1, y, x, w);
-                    $core1______(FWD, 1 << 7, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_08<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 7, y, x, true);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 6, x, y, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 5, y, x, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 4, x, y, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 3, y, x, w);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 2, x, y, w);
-                    core_::<$xn>(FWD, 1 << 7, 1 << 1, y, x, w);
-                    $core1______(FWD, 1 << 8, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_09<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 8, x, y, false);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 7, y, x, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 6, x, y, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 5, y, x, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 4, x, y, w);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 3, y, x, w);
-                    core_::<$xn>(FWD, 1 << 7, 1 << 2, x, y, w);
-                    core_::<$xn>(FWD, 1 << 8, 1 << 1, y, x, w);
-                    $core1______(FWD, 1 << 9, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_10<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 9, y, x, true);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 8, x, y, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 7, y, x, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 6, x, y, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 5, y, x, w);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 4, x, y, w);
-                    core_::<$xn>(FWD, 1 << 7, 1 << 3, y, x, w);
-                    core_::<$xn>(FWD, 1 << 8, 1 << 2, x, y, w);
-                    core_::<$xn>(FWD, 1 << 9, 1 << 1, y, x, w);
-                    $core1______(FWD, 1 << 10, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_11<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 10, x, y, false);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 09, y, x, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 08, x, y, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 07, y, x, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 05, y, x, w);
-                    core_::<$xn>(FWD, 1 << 7, 1 << 04, x, y, w);
-                    core_::<$xn>(FWD, 1 << 8, 1 << 03, y, x, w);
-                    core_::<$xn>(FWD, 1 << 9, 1 << 02, x, y, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 01, y, x, w);
-                    $core1______(FWD, 1 << 11, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_12<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 11, y, x, true);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 10, x, y, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 09, y, x, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 08, x, y, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 07, y, x, w);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 7, 1 << 05, y, x, w);
-                    core_::<$xn>(FWD, 1 << 8, 1 << 04, x, y, w);
-                    core_::<$xn>(FWD, 1 << 9, 1 << 03, y, x, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 02, x, y, w);
-                    core_::<$xn>(FWD, 1 << 11, 1 << 01, y, x, w);
-                    $core1______(FWD, 1 << 12, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_13<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 12, x, y, false);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 11, y, x, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 10, x, y, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 09, y, x, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 08, x, y, w);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 07, y, x, w);
-                    core_::<$xn>(FWD, 1 << 7, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 8, 1 << 05, y, x, w);
-                    core_::<$xn>(FWD, 1 << 9, 1 << 04, x, y, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 03, y, x, w);
-                    core_::<$xn>(FWD, 1 << 11, 1 << 02, x, y, w);
-                    core_::<$xn>(FWD, 1 << 12, 1 << 01, y, x, w);
-                    $core1______(FWD, 1 << 13, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_14<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 13, y, x, true);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 12, x, y, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 11, y, x, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 10, x, y, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 09, y, x, w);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 08, x, y, w);
-                    core_::<$xn>(FWD, 1 << 7, 1 << 07, y, x, w);
-                    core_::<$xn>(FWD, 1 << 8, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 9, 1 << 05, y, x, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 04, x, y, w);
-                    core_::<$xn>(FWD, 1 << 11, 1 << 03, y, x, w);
-                    core_::<$xn>(FWD, 1 << 12, 1 << 02, x, y, w);
-                    core_::<$xn>(FWD, 1 << 13, 1 << 01, y, x, w);
-                    $core1______(FWD, 1 << 14, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_15<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 14, x, y, false);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 13, y, x, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 12, x, y, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 11, y, x, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 10, x, y, w);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 09, y, x, w);
-                    core_::<$xn>(FWD, 1 << 7, 1 << 08, x, y, w);
-                    core_::<$xn>(FWD, 1 << 8, 1 << 07, y, x, w);
-                    core_::<$xn>(FWD, 1 << 9, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 05, y, x, w);
-                    core_::<$xn>(FWD, 1 << 11, 1 << 04, x, y, w);
-                    core_::<$xn>(FWD, 1 << 12, 1 << 03, y, x, w);
-                    core_::<$xn>(FWD, 1 << 13, 1 << 02, x, y, w);
-                    core_::<$xn>(FWD, 1 << 14, 1 << 01, y, x, w);
-                    $core1______(FWD, 1 << 15, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_16<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 15, y, x, true);
-                    core_::<$xn>(FWD, 1 << 2, 1 << 14, x, y, w);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 13, y, x, w);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 12, x, y, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 11, y, x, w);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 10, x, y, w);
-                    core_::<$xn>(FWD, 1 << 7, 1 << 09, y, x, w);
-                    core_::<$xn>(FWD, 1 << 8, 1 << 08, x, y, w);
-                    core_::<$xn>(FWD, 1 << 9, 1 << 07, y, x, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 11, 1 << 05, y, x, w);
-                    core_::<$xn>(FWD, 1 << 12, 1 << 04, x, y, w);
-                    core_::<$xn>(FWD, 1 << 13, 1 << 03, y, x, w);
-                    core_::<$xn>(FWD, 1 << 14, 1 << 02, x, y, w);
-                    core_::<$xn>(FWD, 1 << 15, 1 << 01, y, x, w);
-                    $core1______(FWD, 1 << 16, 1 << 00, x, y, w);
-                }
-            }
-            $(#[$attr])*
-            pub(crate) static $fft: crate::FftImpl = crate::FftImpl {
-                fwd: [
-                    <$fft>::fft_00::<true>,
-                    <$fft>::fft_01::<true>,
-                    <$fft>::fft_02::<true>,
-                    <$fft>::fft_03::<true>,
-                    <$fft>::fft_04::<true>,
-                    <$fft>::fft_05::<true>,
-                    <$fft>::fft_06::<true>,
-                    <$fft>::fft_07::<true>,
-                    <$fft>::fft_08::<true>,
-                    <$fft>::fft_09::<true>,
-                    <$fft>::fft_10::<true>,
-                    <$fft>::fft_11::<true>,
-                    <$fft>::fft_12::<true>,
-                    <$fft>::fft_13::<true>,
-                    <$fft>::fft_14::<true>,
-                    <$fft>::fft_15::<true>,
-                    <$fft>::fft_16::<true>,
-                ],
-                inv: [
-                    <$fft>::fft_00::<false>,
-                    <$fft>::fft_01::<false>,
-                    <$fft>::fft_02::<false>,
-                    <$fft>::fft_03::<false>,
-                    <$fft>::fft_04::<false>,
-                    <$fft>::fft_05::<false>,
-                    <$fft>::fft_06::<false>,
-                    <$fft>::fft_07::<false>,
-                    <$fft>::fft_08::<false>,
-                    <$fft>::fft_09::<false>,
-                    <$fft>::fft_10::<false>,
-                    <$fft>::fft_11::<false>,
-                    <$fft>::fft_12::<false>,
-                    <$fft>::fft_13::<false>,
-                    <$fft>::fft_14::<false>,
-                    <$fft>::fft_15::<false>,
-                    <$fft>::fft_16::<false>,
-                ],
-            };
-            )*
-    };
+struct Dit2<N: nat::Nat>(N);
+impl<N: nat::Nat> nat::Nat for Dit2<N> {
+    const VALUE: usize = N::VALUE;
 }
 
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-use crate::x86::*;
-
-dit2_impl! {
-    pub static DIT2_SCALAR = Fft {
-        core_1: core_::<Scalar>,
-        native: Scalar,
-        x1: Scalar,
-    };
-
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub static DIT2_AVX = Fft {
-        core_1: core_x2::<AvxX2>,
-        native: AvxX2,
-        x1: AvxX1,
-        target: "avx",
-    };
-
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub static DIT2_FMA = Fft {
-        core_1: core_x2::<FmaX2>,
-        native: FmaX2,
-        x1: FmaX1,
-        target: "fma",
-    };
-}
-
-pub(crate) fn runtime_fft() -> crate::FftImpl {
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    if x86_feature_detected!("fma") {
-        return DIT2_FMA;
-    } else if x86_feature_detected!("avx") {
-        return DIT2_AVX;
+/// size 2^3
+impl RecursiveFft for Dit2<nat::N0> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        read_from_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        stockham_dit2_end(simd, fwd, read_from_x, s, x, y);
     }
+}
 
-    DIT2_SCALAR
+impl<N: nat::Nat> RecursiveFft for Dit2<nat::Plus1<N>>
+where
+    Dit2<N>: RecursiveFft,
+{
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        read_from_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        w_init: &[c64xN],
+        w: &[c64],
+    ) {
+        Dit2::<N>::fft_recurse_impl(simd, fwd, !read_from_x, s * 2, y, x, w_init, w);
+        stockham_core(simd, fwd, s, x, y, w_init, w);
+    }
+}
+
+pub(crate) fn fft_impl<c64xN: Pod>(simd: impl FftSimd<c64xN>) -> crate::FftImpl {
+    // special case, for DIT2, fwd and inv are the same
+    let ptrs = [
+        fn_ptr::<true, Dit2<nat::N0>, _, _>(simd),
+        fn_ptr::<true, Dit2<nat::N1>, _, _>(simd),
+        fn_ptr::<true, Dit2<nat::N2>, _, _>(simd),
+        fn_ptr::<true, Dit2<nat::N3>, _, _>(simd),
+        fn_ptr::<true, Dit2<nat::N4>, _, _>(simd),
+        fn_ptr::<true, Dit2<nat::N5>, _, _>(simd),
+        fn_ptr::<true, Dit2<nat::N6>, _, _>(simd),
+        fn_ptr::<true, Dit2<nat::N7>, _, _>(simd),
+        fn_ptr::<true, Dit2<nat::N8>, _, _>(simd),
+        fn_ptr::<true, Dit2<nat::N9>, _, _>(simd),
+    ];
+    crate::FftImpl {
+        fwd: ptrs,
+        inv: ptrs,
+    }
+}
+
+pub fn fft_impl_dispatch(n: usize) -> [fn(&mut [c64], &mut [c64], &[c64], &[c64]); 2] {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if let Some(simd) = pulp::x86::V3::try_new() {
+            if n >= 2 * simd.lane_count() {
+                return fft_impl(simd).make_fn_ptr(n);
+            }
+        }
+    }
+    fft_impl(crate::fft_simd::Scalar).make_fn_ptr(n)
 }

--- a/src/dit4.rs
+++ b/src/dit4.rs
@@ -1,491 +1,327 @@
-// Copyright (c) 2019 OK Ojisan(Takuya OKAHISA)
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy of
-// this software and associated documentation files (the "Software"), to deal in
-// the Software without restriction, including without limitation the rights to
-// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-// of the Software, and to permit persons to whom the Software is furnished to do
-// so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
-use crate::c64;
-use crate::fft_simd::{twid, twid_t, FftSimd64, FftSimd64Ext, FftSimd64X2, FftSimd64X4, Scalar};
-use crate::x86_feature_detected;
+use crate::{
+    c64,
+    dif4::{split_4, split_mut_4},
+    fft_simd::{FftSimd, FftSimdExt, Pod},
+    fn_ptr, nat, RecursiveFft,
+};
 
 #[inline(always)]
-unsafe fn core_<I: FftSimd64>(
+fn stockham_core_1x2<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
     fwd: bool,
-    n: usize,
     s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
+    x: &mut [c64xN],
+    y: &[c64xN],
+    w_init: &[c64xN],
+    _w: &[c64],
 ) {
-    debug_assert_eq!(s % I::COMPLEX_PER_REG, 0);
+    assert_eq!(s, 1);
 
-    let m = n / 4;
-    let big_n = n * s;
-    let big_n0 = 0;
-    let big_n1 = big_n / 4;
-    let big_n2 = big_n1 * 2;
-    let big_n3 = big_n1 * 3;
+    let y = pulp::as_arrays::<4, _>(y).0;
+    let (x0, x1, x2, x3) = split_mut_4(x);
+    let (_, w1, w2, w3) = split_4(w_init);
 
-    for p in 0..m {
-        let sp = s * p;
-        let s4p = 4 * sp;
-        let w1p = I::splat(twid_t(4, big_n, 1, w, sp));
-        let w2p = I::splat(twid_t(4, big_n, 2, w, sp));
-        let w3p = I::splat(twid_t(4, big_n, 3, w, sp));
+    for (y, x0, x1, x2, x3, w1, w2, w3) in izip!(y, x0, x1, x2, x3, w1, w2, w3) {
+        let w1 = *w1;
+        let w2 = *w2;
+        let w3 = *w3;
 
-        let mut q = 0;
-        while q < s {
-            let xq_sp = x.add(q + sp);
-            let yq_s4p = y.add(q + s4p);
+        let ab0 = y[0];
+        let cd0 = y[1];
+        let ab1 = y[2];
+        let cd1 = y[3];
 
-            let a = I::load(yq_s4p.add(0));
-            let b = I::mul(w1p, I::load(yq_s4p.add(s)));
-            let c = I::mul(w2p, I::load(yq_s4p.add(s * 2)));
-            let d = I::mul(w3p, I::load(yq_s4p.add(s * 3)));
+        let a = simd.catlo(ab0, ab1);
+        let b = simd.mul(w1, simd.cathi(ab0, ab1));
+        let c = simd.mul(w2, simd.catlo(cd0, cd1));
+        let d = simd.mul(w3, simd.cathi(cd0, cd1));
 
-            let apc = I::add(a, c);
-            let amc = I::sub(a, c);
+        let apc = simd.add(a, c);
+        let amc = simd.sub(a, c);
+        let bpd = simd.add(b, d);
+        let jbmd = simd.mul_j(fwd, simd.sub(b, d));
 
-            let bpd = I::add(b, d);
-            let jbmd = I::xpj(fwd, I::sub(b, d));
+        *x0 = simd.add(apc, bpd);
+        *x1 = simd.sub(amc, jbmd);
+        *x2 = simd.sub(apc, bpd);
+        *x3 = simd.add(amc, jbmd);
+    }
+}
 
-            I::store(xq_sp.add(big_n0), I::add(apc, bpd));
-            I::store(xq_sp.add(big_n1), I::sub(amc, jbmd));
-            I::store(xq_sp.add(big_n2), I::sub(apc, bpd));
-            I::store(xq_sp.add(big_n3), I::add(amc, jbmd));
+#[inline(always)]
+fn stockham_core_1x4<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    s: usize,
+    x: &mut [c64xN],
+    y: &[c64xN],
+    w_init: &[c64xN],
+    _w: &[c64],
+) {
+    assert_eq!(s, 1);
 
-            q += I::COMPLEX_PER_REG;
+    let y = pulp::as_arrays::<4, _>(y).0;
+    let (x0, x1, x2, x3) = split_mut_4(x);
+    let (_, w1, w2, w3) = split_4(w_init);
+
+    for (y, x0, x1, x2, x3, w1, w2, w3) in izip!(y, x0, x1, x2, x3, w1, w2, w3) {
+        let w1 = *w1;
+        let w2 = *w2;
+        let w3 = *w3;
+
+        let abcd0 = y[0];
+        let abcd1 = y[1];
+        let abcd2 = y[2];
+        let abcd3 = y[3];
+
+        let (a, b, c, d) = simd.transpose(abcd0, abcd1, abcd2, abcd3);
+
+        let a = a;
+        let b = simd.mul(w1, b);
+        let c = simd.mul(w2, c);
+        let d = simd.mul(w3, d);
+
+        let apc = simd.add(a, c);
+        let amc = simd.sub(a, c);
+        let bpd = simd.add(b, d);
+        let jbmd = simd.mul_j(fwd, simd.sub(b, d));
+
+        *x0 = simd.add(apc, bpd);
+        *x1 = simd.sub(amc, jbmd);
+        *x2 = simd.sub(apc, bpd);
+        *x3 = simd.add(amc, jbmd);
+    }
+}
+
+#[inline(always)]
+fn stockham_core_generic<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    s: usize,
+    x: &mut [c64xN],
+    y: &[c64xN],
+    _w_init: &[c64xN],
+    w: &[c64],
+) {
+    assert_eq!(s % simd.lane_count(), 0);
+    let simd_s = s / simd.lane_count();
+
+    let w = pulp::as_arrays::<4, _>(w).0;
+
+    let (x0, x1, x2, x3) = split_mut_4(x);
+    for (x0, x1, x2, x3, y, w) in izip!(
+        x0.chunks_exact_mut(simd_s),
+        x1.chunks_exact_mut(simd_s),
+        x2.chunks_exact_mut(simd_s),
+        x3.chunks_exact_mut(simd_s),
+        y.chunks_exact(4 * simd_s),
+        w.chunks_exact(s),
+    ) {
+        let [_, w1, w2, w3] = w[0];
+
+        let w1 = simd.splat(w1);
+        let w2 = simd.splat(w2);
+        let w3 = simd.splat(w3);
+
+        let (y0, y1, y2, y3) = split_4(y);
+
+        for (x0, x1, x2, x3, y0, y1, y2, y3) in izip!(x0, x1, x2, x3, y0, y1, y2, y3) {
+            let a = *y0;
+            let b = simd.mul(w1, *y1);
+            let c = simd.mul(w2, *y2);
+            let d = simd.mul(w3, *y3);
+
+            let apc = simd.add(a, c);
+            let amc = simd.sub(a, c);
+
+            let bpd = simd.add(b, d);
+            let jbmd = simd.mul_j(fwd, simd.sub(b, d));
+
+            *x0 = simd.add(apc, bpd);
+            *x1 = simd.sub(amc, jbmd);
+            *x2 = simd.sub(apc, bpd);
+            *x3 = simd.add(amc, jbmd);
         }
     }
 }
 
 #[inline(always)]
-#[allow(dead_code)]
-unsafe fn core_x2<I: FftSimd64X2>(
+fn stockham_core<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
     fwd: bool,
-    n: usize,
     s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
+    x: &mut [c64xN],
+    y: &[c64xN],
+    w_init: &[c64xN],
+    w: &[c64],
 ) {
-    debug_assert_eq!(s, 1);
-
-    let big_n = n;
-    let big_n0 = 0;
-    let big_n1 = big_n / 4;
-    let big_n2 = big_n1 * 2;
-    let big_n3 = big_n1 * 3;
-
-    debug_assert_eq!(big_n1 % 2, 0);
-    let mut p = 0;
-    while p < big_n1 {
-        let x_p = x.add(p);
-        let y_4p = y.add(4 * p);
-
-        let w1p = I::load(twid(4, big_n, 1, w, p));
-        let w2p = I::load(twid(4, big_n, 2, w, p));
-        let w3p = I::load(twid(4, big_n, 3, w, p));
-
-        let ab0 = I::load(y_4p.add(0));
-        let cd0 = I::load(y_4p.add(2));
-        let ab1 = I::load(y_4p.add(4));
-        let cd1 = I::load(y_4p.add(6));
-
-        let a = I::catlo(ab0, ab1);
-        let b = I::mul(w1p, I::cathi(ab0, ab1));
-        let c = I::mul(w2p, I::catlo(cd0, cd1));
-        let d = I::mul(w3p, I::cathi(cd0, cd1));
-
-        let apc = I::add(a, c);
-        let amc = I::sub(a, c);
-        let bpd = I::add(b, d);
-        let jbmd = I::xpj(fwd, I::sub(b, d));
-
-        I::store(x_p.add(big_n0), I::add(apc, bpd));
-        I::store(x_p.add(big_n1), I::sub(amc, jbmd));
-        I::store(x_p.add(big_n2), I::sub(apc, bpd));
-        I::store(x_p.add(big_n3), I::add(amc, jbmd));
-
-        p += 2;
-    }
+    // we create a fn pointer that will be force-inlined in release builds
+    // but not in debug builds. this helps keep compile times low, since dead code
+    // elimination handles this well in release builds. and the function pointer indirection
+    // prevents inlining in debug builds.
+    let stockham = if s == 1 && simd.lane_count() == 2 {
+        stockham_core_1x2
+    } else if s == 1 && simd.lane_count() == 4 {
+        stockham_core_1x4
+    } else {
+        stockham_core_generic
+    };
+    stockham(simd, fwd, s, x, y, w_init, w);
 }
 
 #[inline(always)]
-#[allow(dead_code)]
-unsafe fn core_x4<I2: FftSimd64X2, I4: FftSimd64X4>(
+fn last_butterfly<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
     fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
-) {
-    debug_assert_eq!(s, 1);
-    if n == 8 {
-        return core_x2::<I2>(fwd, n, s, x, y, w);
-    }
+    x0: c64xN,
+    x1: c64xN,
+    x2: c64xN,
+    x3: c64xN,
+) -> (c64xN, c64xN, c64xN, c64xN) {
+    let apc = simd.add(x0, x2);
+    let amc = simd.sub(x0, x2);
+    let bpd = simd.add(x1, x3);
+    let jbmd = simd.mul_j(fwd, simd.sub(x1, x3));
 
-    let big_n = n;
-    let big_n0 = 0;
-    let big_n1 = big_n / 4;
-    let big_n2 = big_n1 * 2;
-    let big_n3 = big_n1 * 3;
-
-    debug_assert_eq!(big_n1 % 4, 0);
-    let mut p = 0;
-    while p < big_n1 {
-        let x_p = x.add(p);
-        let y_4p = y.add(4 * p);
-
-        let w1p = I4::load(twid(4, big_n, 1, w, p));
-        let w2p = I4::load(twid(4, big_n, 2, w, p));
-        let w3p = I4::load(twid(4, big_n, 3, w, p));
-
-        let abcd0 = I4::load(y_4p.add(0));
-        let abcd1 = I4::load(y_4p.add(4));
-        let abcd2 = I4::load(y_4p.add(8));
-        let abcd3 = I4::load(y_4p.add(12));
-
-        let (a, b, c, d) = I4::transpose(abcd0, abcd1, abcd2, abcd3);
-
-        let a = a;
-        let b = I4::mul(w1p, b);
-        let c = I4::mul(w2p, c);
-        let d = I4::mul(w3p, d);
-
-        let apc = I4::add(a, c);
-        let amc = I4::sub(a, c);
-        let bpd = I4::add(b, d);
-        let jbmd = I4::xpj(fwd, I4::sub(b, d));
-
-        I4::store(x_p.add(big_n0), I4::add(apc, bpd));
-        I4::store(x_p.add(big_n1), I4::sub(amc, jbmd));
-        I4::store(x_p.add(big_n2), I4::sub(apc, bpd));
-        I4::store(x_p.add(big_n3), I4::add(amc, jbmd));
-
-        p += 4;
-    }
-}
-
-#[inline(always)]
-pub unsafe fn end_4<I: FftSimd64>(
-    fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    eo: bool,
-) {
-    debug_assert_eq!(n, 4);
-    debug_assert_eq!(s % I::COMPLEX_PER_REG, 0);
-    let z = if eo { y } else { x };
-
-    let mut q = 0;
-    while q < s {
-        let xq = x.add(q);
-        let zq = z.add(q);
-
-        let a = I::load(zq.add(0));
-        let b = I::load(zq.add(s));
-        let c = I::load(zq.add(s * 2));
-        let d = I::load(zq.add(s * 3));
-
-        let apc = I::add(a, c);
-        let amc = I::sub(a, c);
-        let bpd = I::add(b, d);
-        let jbmd = I::xpj(fwd, I::sub(b, d));
-
-        I::store(xq.add(0), I::add(apc, bpd));
-        I::store(xq.add(s), I::sub(amc, jbmd));
-        I::store(xq.add(s * 2), I::sub(apc, bpd));
-        I::store(xq.add(s * 3), I::add(amc, jbmd));
-
-        q += I::COMPLEX_PER_REG;
-    }
-}
-
-#[inline(always)]
-pub unsafe fn end_2<I: FftSimd64>(
-    _fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    eo: bool,
-) {
-    debug_assert_eq!(n, 2);
-    debug_assert_eq!(s % I::COMPLEX_PER_REG, 0);
-    let z = if eo { y } else { x };
-
-    let mut q = 0;
-    while q < s {
-        let xq = x.add(q);
-        let zq = z.add(q);
-
-        let a = I::load(zq.add(0));
-        let b = I::load(zq.add(s));
-
-        I::store(xq.add(0), I::add(a, b));
-        I::store(xq.add(s), I::sub(a, b));
-
-        q += I::COMPLEX_PER_REG;
-    }
-}
-
-macro_rules! dit4_impl {
     (
-        $(
-            $(#[$attr: meta])*
-            pub static $fft: ident = Fft {
-                core_1: $core1______: expr,
-                native: $xn: ty,
-                x1: $x1: ty,
-                $(target: $target: tt,)?
-            };
-        )*
-    ) => {
-        $(
-            #[allow(missing_copy_implementations)]
-            #[allow(non_camel_case_types)]
-            #[allow(dead_code)]
-            $(#[$attr])*
-            struct $fft {
-                __private: (),
-            }
-            #[allow(unused_variables)]
-            #[allow(dead_code)]
-            $(#[$attr])*
-            impl $fft {
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_00<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {}
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_01<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$x1>(FWD, 1 << 1, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_02<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$x1>(FWD, 1 << 2, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_03<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 2, y, x, true);
-                    $core1______(FWD, 1 << 3, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_04<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$xn>(FWD, 1 << 2, 1 << 2, y, x, true);
-                    $core1______(FWD, 1 << 4, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_05<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 4, x, y, false);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 2, y, x, w);
-                    $core1______(FWD, 1 << 5, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_06<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$xn>(FWD, 1 << 2, 1 << 4, x, y, false);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 2, y, x, w);
-                    $core1______(FWD, 1 << 6, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_07<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 6, y, x, true);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 4, x, y, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 2, y, x, w);
-                    $core1______(FWD, 1 << 7, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_08<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$xn>(FWD, 1 << 2, 1 << 6, y, x, true);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 4, x, y, w);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 2, y, x, w);
-                    $core1______(FWD, 1 << 8, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_09<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 8, x, y, false);
-                    core_::<$xn>(FWD, 1 << 3, 1 << 6, y, x, w);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 4, x, y, w);
-                    core_::<$xn>(FWD, 1 << 7, 1 << 2, y, x, w);
-                    $core1______(FWD, 1 << 9, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_10<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$xn>(FWD, 1 << 02, 1 << 8, x, y, false);
-                    core_::<$xn>(FWD, 1 << 04, 1 << 6, y, x, w);
-                    core_::<$xn>(FWD, 1 << 06, 1 << 4, x, y, w);
-                    core_::<$xn>(FWD, 1 << 08, 1 << 2, y, x, w);
-                    $core1______(FWD, 1 << 10, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_11<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 01, 1 << 10, y, x, true);
-                    core_::<$xn>(FWD, 1 << 03, 1 << 08, x, y, w);
-                    core_::<$xn>(FWD, 1 << 05, 1 << 06, y, x, w);
-                    core_::<$xn>(FWD, 1 << 07, 1 << 04, x, y, w);
-                    core_::<$xn>(FWD, 1 << 09, 1 << 02, y, x, w);
-                    $core1______(FWD, 1 << 11, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_12<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$xn>(FWD, 1 << 02, 1 << 10, y, x, true);
-                    core_::<$xn>(FWD, 1 << 04, 1 << 08, x, y, w);
-                    core_::<$xn>(FWD, 1 << 06, 1 << 06, y, x, w);
-                    core_::<$xn>(FWD, 1 << 08, 1 << 04, x, y, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 02, y, x, w);
-                    $core1______(FWD, 1 << 12, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_13<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 01, 1 << 12, x, y, false);
-                    core_::<$xn>(FWD, 1 << 03, 1 << 10, y, x, w);
-                    core_::<$xn>(FWD, 1 << 05, 1 << 08, x, y, w);
-                    core_::<$xn>(FWD, 1 << 07, 1 << 06, y, x, w);
-                    core_::<$xn>(FWD, 1 << 09, 1 << 04, x, y, w);
-                    core_::<$xn>(FWD, 1 << 11, 1 << 02, y, x, w);
-                    $core1______(FWD, 1 << 13, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_14<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$xn>(FWD, 1 << 02, 1 << 12, x, y, false);
-                    core_::<$xn>(FWD, 1 << 04, 1 << 10, y, x, w);
-                    core_::<$xn>(FWD, 1 << 06, 1 << 08, x, y, w);
-                    core_::<$xn>(FWD, 1 << 08, 1 << 06, y, x, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 04, x, y, w);
-                    core_::<$xn>(FWD, 1 << 12, 1 << 02, y, x, w);
-                    $core1______(FWD, 1 << 14, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_15<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 01, 1 << 14, y, x, true);
-                    core_::<$xn>(FWD, 1 << 03, 1 << 12, x, y, w);
-                    core_::<$xn>(FWD, 1 << 05, 1 << 10, y, x, w);
-                    core_::<$xn>(FWD, 1 << 07, 1 << 08, x, y, w);
-                    core_::<$xn>(FWD, 1 << 09, 1 << 06, y, x, w);
-                    core_::<$xn>(FWD, 1 << 11, 1 << 04, x, y, w);
-                    core_::<$xn>(FWD, 1 << 13, 1 << 02, y, x, w);
-                    $core1______(FWD, 1 << 15, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_16<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$xn>(FWD, 1 << 02, 1 << 14, y, x, true);
-                    core_::<$xn>(FWD, 1 << 04, 1 << 12, x, y, w);
-                    core_::<$xn>(FWD, 1 << 06, 1 << 10, y, x, w);
-                    core_::<$xn>(FWD, 1 << 08, 1 << 08, x, y, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 06, y, x, w);
-                    core_::<$xn>(FWD, 1 << 12, 1 << 04, x, y, w);
-                    core_::<$xn>(FWD, 1 << 14, 1 << 02, y, x, w);
-                    $core1______(FWD, 1 << 16, 1 << 00, x, y, w);
-                }
-            }
-            $(#[$attr])*
-            pub(crate) static $fft: crate::FftImpl = crate::FftImpl {
-                fwd: [
-                    <$fft>::fft_00::<true>,
-                    <$fft>::fft_01::<true>,
-                    <$fft>::fft_02::<true>,
-                    <$fft>::fft_03::<true>,
-                    <$fft>::fft_04::<true>,
-                    <$fft>::fft_05::<true>,
-                    <$fft>::fft_06::<true>,
-                    <$fft>::fft_07::<true>,
-                    <$fft>::fft_08::<true>,
-                    <$fft>::fft_09::<true>,
-                    <$fft>::fft_10::<true>,
-                    <$fft>::fft_11::<true>,
-                    <$fft>::fft_12::<true>,
-                    <$fft>::fft_13::<true>,
-                    <$fft>::fft_14::<true>,
-                    <$fft>::fft_15::<true>,
-                    <$fft>::fft_16::<true>,
-                ],
-                inv: [
-                    <$fft>::fft_00::<false>,
-                    <$fft>::fft_01::<false>,
-                    <$fft>::fft_02::<false>,
-                    <$fft>::fft_03::<false>,
-                    <$fft>::fft_04::<false>,
-                    <$fft>::fft_05::<false>,
-                    <$fft>::fft_06::<false>,
-                    <$fft>::fft_07::<false>,
-                    <$fft>::fft_08::<false>,
-                    <$fft>::fft_09::<false>,
-                    <$fft>::fft_10::<false>,
-                    <$fft>::fft_11::<false>,
-                    <$fft>::fft_12::<false>,
-                    <$fft>::fft_13::<false>,
-                    <$fft>::fft_14::<false>,
-                    <$fft>::fft_15::<false>,
-                    <$fft>::fft_16::<false>,
-                ],
-            };
-            )*
-    };
+        simd.add(apc, bpd),
+        simd.sub(amc, jbmd),
+        simd.sub(apc, bpd),
+        simd.add(amc, jbmd),
+    )
 }
 
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-use crate::x86::*;
+#[inline(always)]
+pub fn stockham_dit4_end<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    read_from_x: bool,
+    s: usize,
+    x: &mut [c64xN],
+    y: &mut [c64xN],
+) {
+    assert_eq!(s % simd.lane_count(), 0);
+    let (x0, x1, x2, x3) = split_mut_4(x);
+    let (y0, y1, y2, y3) = split_mut_4(y);
 
-dit4_impl! {
-    pub static DIT4_SCALAR = Fft {
-        core_1: core_::<Scalar>,
-        native: Scalar,
-        x1: Scalar,
-    };
+    // we create a fn pointer that will be force-inlined in release builds
+    // but not in debug builds. this helps keep compile times low, since dead code
+    // elimination handles this well in release builds. and the function pointer indirection
+    // prevents inlining in debug builds.
+    let last_butterfly: fn(_, _, _, _, _, _) -> _ = last_butterfly;
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub static DIT4_AVX = Fft {
-        core_1: core_x2::<AvxX2>,
-        native: AvxX2,
-        x1: AvxX1,
-        target: "avx",
-    };
-
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub static DIT4_FMA = Fft {
-        core_1: core_x2::<FmaX2>,
-        native: FmaX2,
-        x1: FmaX1,
-        target: "fma",
-    };
-
-    #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
-    pub static DIT4_AVX512 = Fft {
-        core_1: core_x4::<Avx512X2, Avx512X4>,
-        native: Avx512X4,
-        x1: Avx512X1,
-        target: "avx512f",
-    };
+    if read_from_x {
+        for (x0, x1, x2, x3) in izip!(x0, x1, x2, x3) {
+            (*x0, *x1, *x2, *x3) = last_butterfly(simd, fwd, *x0, *x1, *x2, *x3);
+        }
+    } else {
+        for (x0, x1, x2, x3, y0, y1, y2, y3) in izip!(x0, x1, x2, x3, y0, y1, y2, y3) {
+            (*x0, *x1, *x2, *x3) = last_butterfly(simd, fwd, *y0, *y1, *y2, *y3);
+        }
+    }
 }
 
-pub(crate) fn runtime_fft() -> crate::FftImpl {
-    #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
-    if x86_feature_detected!("avx512f") {
-        return DIT4_AVX512;
-    }
+struct Dit4<N: nat::Nat>(N);
+impl<N: nat::Nat> nat::Nat for Dit4<N> {
+    const VALUE: usize = N::VALUE;
+}
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    if x86_feature_detected!("fma") {
-        return DIT4_FMA;
-    } else if x86_feature_detected!("avx") {
-        return DIT4_AVX;
+// size 2
+impl RecursiveFft for Dit4<nat::N0> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        read_from_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        crate::dit2::stockham_dit2_end(simd, fwd, read_from_x, s, x, y);
     }
+}
 
-    DIT4_SCALAR
+// size 4
+impl RecursiveFft for Dit4<nat::N1> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        read_from_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        stockham_dit4_end(simd, fwd, read_from_x, s, x, y);
+    }
+}
+
+impl<N: nat::Nat> RecursiveFft for Dit4<nat::Plus2<N>>
+where
+    Dit4<N>: RecursiveFft,
+{
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        read_from_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        w_init: &[c64xN],
+        w: &[c64],
+    ) {
+        Dit4::<N>::fft_recurse_impl(simd, fwd, !read_from_x, s * 4, y, x, w_init, w);
+        stockham_core(simd, fwd, s, x, y, w_init, w);
+    }
+}
+
+pub(crate) fn fft_impl<c64xN: Pod>(simd: impl FftSimd<c64xN>) -> crate::FftImpl {
+    let fwd = [
+        fn_ptr::<true, Dit4<nat::N0>, _, _>(simd),
+        fn_ptr::<true, Dit4<nat::N1>, _, _>(simd),
+        fn_ptr::<true, Dit4<nat::N2>, _, _>(simd),
+        fn_ptr::<true, Dit4<nat::N3>, _, _>(simd),
+        fn_ptr::<true, Dit4<nat::N4>, _, _>(simd),
+        fn_ptr::<true, Dit4<nat::N5>, _, _>(simd),
+        fn_ptr::<true, Dit4<nat::N6>, _, _>(simd),
+        fn_ptr::<true, Dit4<nat::N7>, _, _>(simd),
+        fn_ptr::<true, Dit4<nat::N8>, _, _>(simd),
+        fn_ptr::<true, Dit4<nat::N9>, _, _>(simd),
+    ];
+    let inv = [
+        fn_ptr::<false, Dit4<nat::N0>, _, _>(simd),
+        fn_ptr::<false, Dit4<nat::N1>, _, _>(simd),
+        fn_ptr::<false, Dit4<nat::N2>, _, _>(simd),
+        fn_ptr::<false, Dit4<nat::N3>, _, _>(simd),
+        fn_ptr::<false, Dit4<nat::N4>, _, _>(simd),
+        fn_ptr::<false, Dit4<nat::N5>, _, _>(simd),
+        fn_ptr::<false, Dit4<nat::N6>, _, _>(simd),
+        fn_ptr::<false, Dit4<nat::N7>, _, _>(simd),
+        fn_ptr::<false, Dit4<nat::N8>, _, _>(simd),
+        fn_ptr::<false, Dit4<nat::N9>, _, _>(simd),
+    ];
+    crate::FftImpl { fwd, inv }
+}
+
+pub fn fft_impl_dispatch(n: usize) -> [fn(&mut [c64], &mut [c64], &[c64], &[c64]); 2] {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        #[cfg(feature = "nightly")]
+        if let Some(simd) = pulp::x86::V4::try_new() {
+            if n >= 4 * simd.lane_count() {
+                return fft_impl(simd).make_fn_ptr(n);
+            }
+        }
+        if let Some(simd) = pulp::x86::V3::try_new() {
+            if n >= 4 * simd.lane_count() {
+                return fft_impl(simd).make_fn_ptr(n);
+            }
+        }
+    }
+    fft_impl(crate::fft_simd::Scalar).make_fn_ptr(n)
 }

--- a/src/dit8.rs
+++ b/src/dit8.rs
@@ -1,560 +1,473 @@
-// Copyright (c) 2019 OK Ojisan(Takuya OKAHISA)
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy of
-// this software and associated documentation files (the "Software"), to deal in
-// the Software without restriction, including without limitation the rights to
-// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-// of the Software, and to permit persons to whom the Software is furnished to do
-// so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
-use crate::c64;
-use crate::dit4::{end_2, end_4};
-use crate::fft_simd::{twid, twid_t, FftSimd64, FftSimd64Ext, FftSimd64X2, FftSimd64X4, Scalar};
-use crate::x86_feature_detected;
+use crate::{
+    c64,
+    dif8::{split_8, split_mut_8},
+    fft_simd::{FftSimd, FftSimdExt, Pod},
+    fn_ptr, nat, RecursiveFft,
+};
 
 #[inline(always)]
-#[rustfmt::skip]
-unsafe fn core_<I: FftSimd64>(
+fn stockham_core_1x2<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
     fwd: bool,
-    n: usize,
     s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
+    x: &mut [c64xN],
+    y: &[c64xN],
+    w_init: &[c64xN],
+    _w: &[c64],
 ) {
-    debug_assert_eq!(s % I::COMPLEX_PER_REG, 0);
+    assert_eq!(s, 1);
 
-    let m = n / 8;
-    let big_n = n * s;
-    let big_n0 = 0;
-    let big_n1 = big_n / 8;
-    let big_n2 = big_n1 * 2;
-    let big_n3 = big_n1 * 3;
-    let big_n4 = big_n1 * 4;
-    let big_n5 = big_n1 * 5;
-    let big_n6 = big_n1 * 6;
-    let big_n7 = big_n1 * 7;
+    let y = pulp::as_arrays::<8, _>(y).0;
+    let (x0, x1, x2, x3, x4, x5, x6, x7) = split_mut_8(x);
+    let (_, w1, w2, w3, w4, w5, w6, w7) = split_8(w_init);
 
-    for p in 0..m {
-        let sp = s * p;
-        let s8p = 8 * sp;
-        let w1p = I::splat(twid_t(8, big_n, 1, w, sp));
-        let w2p = I::splat(twid_t(8, big_n, 2, w, sp));
-        let w3p = I::splat(twid_t(8, big_n, 3, w, sp));
-        let w4p = I::splat(twid_t(8, big_n, 4, w, sp));
-        let w5p = I::splat(twid_t(8, big_n, 5, w, sp));
-        let w6p = I::splat(twid_t(8, big_n, 6, w, sp));
-        let w7p = I::splat(twid_t(8, big_n, 7, w, sp));
+    for ((x0, x1, x2, x3, x4, x5, x6, x7), y, (w1, w2, w3, w4, w5, w6, w7)) in izip!(
+        izip!(x0, x1, x2, x3, x4, x5, x6, x7),
+        y,
+        izip!(w1, w2, w3, w4, w5, w6, w7),
+    ) {
+        let w1 = *w1;
+        let w2 = *w2;
+        let w3 = *w3;
+        let w4 = *w4;
+        let w5 = *w5;
+        let w6 = *w6;
+        let w7 = *w7;
 
-        let mut q = 0;
-        while q < s {
-            let xq_sp = x.add(q + sp);
-            let yq_s8p = y.add(q + s8p);
+        let ab_0 = y[0];
+        let cd_0 = y[1];
+        let ef_0 = y[2];
+        let gh_0 = y[3];
+        let ab_1 = y[4];
+        let cd_1 = y[5];
+        let ef_1 = y[6];
+        let gh_1 = y[7];
 
-            let y0 = I::load(yq_s8p.add(0));
-            let y1 = I::mul(w1p, I::load(yq_s8p.add(s)));
-            let y2 = I::mul(w2p, I::load(yq_s8p.add(s * 2)));
-            let y3 = I::mul(w3p, I::load(yq_s8p.add(s * 3)));
-            let y4 = I::mul(w4p, I::load(yq_s8p.add(s * 4)));
-            let y5 = I::mul(w5p, I::load(yq_s8p.add(s * 5)));
-            let y6 = I::mul(w6p, I::load(yq_s8p.add(s * 6)));
-            let y7 = I::mul(w7p, I::load(yq_s8p.add(s * 7)));
-            let a04 = I::add(y0, y4);
-            let s04 = I::sub(y0, y4);
-            let a26 = I::add(y2, y6);
-            let js26 = I::xpj(fwd, I::sub(y2, y6));
-            let a15 = I::add(y1, y5);
-            let s15 = I::sub(y1, y5);
-            let a37 = I::add(y3, y7);
-            let js37 = I::xpj(fwd, I::sub(y3, y7));
+        let y0 = simd.catlo(ab_0, ab_1);
+        let y1 = simd.mul(w1, simd.cathi(ab_0, ab_1));
+        let y2 = simd.mul(w2, simd.catlo(cd_0, cd_1));
+        let y3 = simd.mul(w3, simd.cathi(cd_0, cd_1));
+        let y4 = simd.mul(w4, simd.catlo(ef_0, ef_1));
+        let y5 = simd.mul(w5, simd.cathi(ef_0, ef_1));
+        let y6 = simd.mul(w6, simd.catlo(gh_0, gh_1));
+        let y7 = simd.mul(w7, simd.cathi(gh_0, gh_1));
 
-            let a04_p1_a26 = I::add(a04, a26);
-            let a15_p1_a37 = I::add(a15, a37);
-            I::store(xq_sp.add(big_n0), I::add(a04_p1_a26, a15_p1_a37));
-            I::store(xq_sp.add(big_n4), I::sub(a04_p1_a26, a15_p1_a37));
+        let a04 = simd.add(y0, y4);
+        let s04 = simd.sub(y0, y4);
+        let a26 = simd.add(y2, y6);
+        let js26 = simd.mul_j(fwd, simd.sub(y2, y6));
+        let a15 = simd.add(y1, y5);
+        let s15 = simd.sub(y1, y5);
+        let a37 = simd.add(y3, y7);
+        let js37 = simd.mul_j(fwd, simd.sub(y3, y7));
 
-            let s04_mj_s26 = I::sub(s04, js26);
-            let w8_s15_mj_s37 = I::xw8(fwd, I::sub(s15, js37));
-            I::store(xq_sp.add(big_n1), I::add(s04_mj_s26, w8_s15_mj_s37));
-            I::store(xq_sp.add(big_n5), I::sub(s04_mj_s26, w8_s15_mj_s37));
+        let a04_p1_a26 = simd.add(a04, a26);
+        let a15_p1_a37 = simd.add(a15, a37);
+        *x0 = simd.add(a04_p1_a26, a15_p1_a37);
+        *x4 = simd.sub(a04_p1_a26, a15_p1_a37);
 
-            let a04_m1_a26 = I::sub(a04, a26);
-            let j_a15_m1_a37 = I::xpj(fwd, I::sub(a15, a37));
-            I::store(xq_sp.add(big_n2), I::sub(a04_m1_a26, j_a15_m1_a37));
-            I::store(xq_sp.add(big_n6), I::add(a04_m1_a26, j_a15_m1_a37));
+        let s04_mj_s26 = simd.sub(s04, js26);
+        let w8_s15_mj_s37 = simd.mul_exp_neg_pi_over_8(fwd, simd.sub(s15, js37));
+        *x1 = simd.add(s04_mj_s26, w8_s15_mj_s37);
+        *x5 = simd.sub(s04_mj_s26, w8_s15_mj_s37);
 
-            let s04_pj_s26 = I::add(s04, js26);
-            let v8_s15_pj_s37 = I::xv8(fwd, I::add(s15, js37));
-            I::store(xq_sp.add(big_n3), I::sub(s04_pj_s26, v8_s15_pj_s37));
-            I::store(xq_sp.add(big_n7), I::add(s04_pj_s26, v8_s15_pj_s37));
+        let a04_m1_a26 = simd.sub(a04, a26);
+        let j_a15_m1_a37 = simd.mul_j(fwd, simd.sub(a15, a37));
+        *x2 = simd.sub(a04_m1_a26, j_a15_m1_a37);
+        *x6 = simd.add(a04_m1_a26, j_a15_m1_a37);
 
-            q += I::COMPLEX_PER_REG;
+        let s04_pj_s26 = simd.add(s04, js26);
+        let v8_s15_pj_s37 = simd.mul_exp_pi_over_8(fwd, simd.add(s15, js37));
+        *x3 = simd.sub(s04_pj_s26, v8_s15_pj_s37);
+        *x7 = simd.add(s04_pj_s26, v8_s15_pj_s37);
+    }
+}
+
+#[inline(always)]
+fn stockham_core_1x4<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    s: usize,
+    x: &mut [c64xN],
+    y: &[c64xN],
+    w_init: &[c64xN],
+    _w: &[c64],
+) {
+    assert_eq!(s, 1);
+
+    let y = pulp::as_arrays::<8, _>(y).0;
+    let (x0, x1, x2, x3, x4, x5, x6, x7) = split_mut_8(x);
+    let (_, w1, w2, w3, w4, w5, w6, w7) = split_8(w_init);
+
+    for ((x0, x1, x2, x3, x4, x5, x6, x7), y, (w1, w2, w3, w4, w5, w6, w7)) in izip!(
+        izip!(x0, x1, x2, x3, x4, x5, x6, x7),
+        y,
+        izip!(w1, w2, w3, w4, w5, w6, w7),
+    ) {
+        let w1 = *w1;
+        let w2 = *w2;
+        let w3 = *w3;
+        let w4 = *w4;
+        let w5 = *w5;
+        let w6 = *w6;
+        let w7 = *w7;
+
+        let abcd_0 = y[0];
+        let efgh_0 = y[1];
+        let abcd_1 = y[2];
+        let efgh_1 = y[3];
+        let abcd_2 = y[4];
+        let efgh_2 = y[5];
+        let abcd_3 = y[6];
+        let efgh_3 = y[7];
+
+        let (a, b, c, d) = simd.transpose(abcd_0, abcd_1, abcd_2, abcd_3);
+        let (e, f, g, h) = simd.transpose(efgh_0, efgh_1, efgh_2, efgh_3);
+
+        let y0 = a;
+        let y1 = simd.mul(w1, b);
+        let y2 = simd.mul(w2, c);
+        let y3 = simd.mul(w3, d);
+        let y4 = simd.mul(w4, e);
+        let y5 = simd.mul(w5, f);
+        let y6 = simd.mul(w6, g);
+        let y7 = simd.mul(w7, h);
+
+        let a04 = simd.add(y0, y4);
+        let s04 = simd.sub(y0, y4);
+        let a26 = simd.add(y2, y6);
+        let js26 = simd.mul_j(fwd, simd.sub(y2, y6));
+        let a15 = simd.add(y1, y5);
+        let s15 = simd.sub(y1, y5);
+        let a37 = simd.add(y3, y7);
+        let js37 = simd.mul_j(fwd, simd.sub(y3, y7));
+
+        let a04_p1_a26 = simd.add(a04, a26);
+        let a15_p1_a37 = simd.add(a15, a37);
+        *x0 = simd.add(a04_p1_a26, a15_p1_a37);
+        *x4 = simd.sub(a04_p1_a26, a15_p1_a37);
+
+        let s04_mj_s26 = simd.sub(s04, js26);
+        let w8_s15_mj_s37 = simd.mul_exp_neg_pi_over_8(fwd, simd.sub(s15, js37));
+        *x1 = simd.add(s04_mj_s26, w8_s15_mj_s37);
+        *x5 = simd.sub(s04_mj_s26, w8_s15_mj_s37);
+
+        let a04_m1_a26 = simd.sub(a04, a26);
+        let j_a15_m1_a37 = simd.mul_j(fwd, simd.sub(a15, a37));
+        *x2 = simd.sub(a04_m1_a26, j_a15_m1_a37);
+        *x6 = simd.add(a04_m1_a26, j_a15_m1_a37);
+
+        let s04_pj_s26 = simd.add(s04, js26);
+        let v8_s15_pj_s37 = simd.mul_exp_pi_over_8(fwd, simd.add(s15, js37));
+        *x3 = simd.sub(s04_pj_s26, v8_s15_pj_s37);
+        *x7 = simd.add(s04_pj_s26, v8_s15_pj_s37);
+    }
+}
+
+#[inline(always)]
+fn stockham_core_generic<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    s: usize,
+    x: &mut [c64xN],
+    y: &[c64xN],
+    _w_init: &[c64xN],
+    w: &[c64],
+) {
+    assert_eq!(s % simd.lane_count(), 0);
+    let simd_s = s / simd.lane_count();
+
+    let w = pulp::as_arrays::<8, _>(w).0;
+
+    let (x0, x1, x2, x3, x4, x5, x6, x7) = split_mut_8(x);
+
+    for (x0, x1, x2, x3, x4, x5, x6, x7, y, w) in izip!(
+        x0.chunks_exact_mut(simd_s),
+        x1.chunks_exact_mut(simd_s),
+        x2.chunks_exact_mut(simd_s),
+        x3.chunks_exact_mut(simd_s),
+        x4.chunks_exact_mut(simd_s),
+        x5.chunks_exact_mut(simd_s),
+        x6.chunks_exact_mut(simd_s),
+        x7.chunks_exact_mut(simd_s),
+        y.chunks_exact(8 * simd_s),
+        w.chunks_exact(s),
+    ) {
+        let [_, w1, w2, w3, w4, w5, w6, w7] = w[0];
+
+        let w1 = simd.splat(w1);
+        let w2 = simd.splat(w2);
+        let w3 = simd.splat(w3);
+        let w4 = simd.splat(w4);
+        let w5 = simd.splat(w5);
+        let w6 = simd.splat(w6);
+        let w7 = simd.splat(w7);
+
+        let (y0, y1, y2, y3, y4, y5, y6, y7) = split_8(y);
+
+        for ((x0, x1, x2, x3, x4, x5, x6, x7), (y0, y1, y2, y3, y4, y5, y6, y7)) in izip!(
+            izip!(x0, x1, x2, x3, x4, x5, x6, x7),
+            izip!(y0, y1, y2, y3, y4, y5, y6, y7),
+        ) {
+            let y0 = *y0;
+            let y1 = simd.mul(w1, *y1);
+            let y2 = simd.mul(w2, *y2);
+            let y3 = simd.mul(w3, *y3);
+            let y4 = simd.mul(w4, *y4);
+            let y5 = simd.mul(w5, *y5);
+            let y6 = simd.mul(w6, *y6);
+            let y7 = simd.mul(w7, *y7);
+            let a04 = simd.add(y0, y4);
+            let s04 = simd.sub(y0, y4);
+            let a26 = simd.add(y2, y6);
+            let js26 = simd.mul_j(fwd, simd.sub(y2, y6));
+            let a15 = simd.add(y1, y5);
+            let s15 = simd.sub(y1, y5);
+            let a37 = simd.add(y3, y7);
+            let js37 = simd.mul_j(fwd, simd.sub(y3, y7));
+
+            let a04_p1_a26 = simd.add(a04, a26);
+            let a15_p1_a37 = simd.add(a15, a37);
+            *x0 = simd.add(a04_p1_a26, a15_p1_a37);
+            *x4 = simd.sub(a04_p1_a26, a15_p1_a37);
+
+            let s04_mj_s26 = simd.sub(s04, js26);
+            let w8_s15_mj_s37 = simd.mul_exp_neg_pi_over_8(fwd, simd.sub(s15, js37));
+            *x1 = simd.add(s04_mj_s26, w8_s15_mj_s37);
+            *x5 = simd.sub(s04_mj_s26, w8_s15_mj_s37);
+
+            let a04_m1_a26 = simd.sub(a04, a26);
+            let j_a15_m1_a37 = simd.mul_j(fwd, simd.sub(a15, a37));
+            *x2 = simd.sub(a04_m1_a26, j_a15_m1_a37);
+            *x6 = simd.add(a04_m1_a26, j_a15_m1_a37);
+
+            let s04_pj_s26 = simd.add(s04, js26);
+            let v8_s15_pj_s37 = simd.mul_exp_pi_over_8(fwd, simd.add(s15, js37));
+            *x3 = simd.sub(s04_pj_s26, v8_s15_pj_s37);
+            *x7 = simd.add(s04_pj_s26, v8_s15_pj_s37);
         }
     }
 }
 
 #[inline(always)]
-#[allow(dead_code)]
-unsafe fn core_x2<I: FftSimd64X2>(
+fn stockham_core<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
     fwd: bool,
-    n: usize,
     s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
+    x: &mut [c64xN],
+    y: &[c64xN],
+    w_init: &[c64xN],
+    w: &[c64],
 ) {
-    debug_assert_eq!(s, 1);
-    debug_assert_eq!(I::COMPLEX_PER_REG, 2);
-
-    let big_n = n;
-    let big_n0 = 0;
-    let big_n1 = big_n / 8;
-    let big_n2 = big_n1 * 2;
-    let big_n3 = big_n1 * 3;
-    let big_n4 = big_n1 * 4;
-    let big_n5 = big_n1 * 5;
-    let big_n6 = big_n1 * 6;
-    let big_n7 = big_n1 * 7;
-
-    let mut p = 0;
-    while p < big_n1 {
-        let x_p = x.add(p);
-        let y_8p = y.add(8 * p);
-
-        let w1p = I::load(twid(8, big_n, 1, w, p));
-        let w2p = I::load(twid(8, big_n, 2, w, p));
-        let w3p = I::load(twid(8, big_n, 3, w, p));
-        let w4p = I::load(twid(8, big_n, 4, w, p));
-        let w5p = I::load(twid(8, big_n, 5, w, p));
-        let w6p = I::load(twid(8, big_n, 6, w, p));
-        let w7p = I::load(twid(8, big_n, 7, w, p));
-        let ab_0 = I::load(y_8p.add(0));
-        let cd_0 = I::load(y_8p.add(2));
-        let ef_0 = I::load(y_8p.add(4));
-        let gh_0 = I::load(y_8p.add(6));
-        let ab_1 = I::load(y_8p.add(8));
-        let cd_1 = I::load(y_8p.add(10));
-        let ef_1 = I::load(y_8p.add(12));
-        let gh_1 = I::load(y_8p.add(14));
-        let y0 = I::catlo(ab_0, ab_1);
-        let y1 = I::mul(w1p, I::cathi(ab_0, ab_1));
-        let y2 = I::mul(w2p, I::catlo(cd_0, cd_1));
-        let y3 = I::mul(w3p, I::cathi(cd_0, cd_1));
-        let y4 = I::mul(w4p, I::catlo(ef_0, ef_1));
-        let y5 = I::mul(w5p, I::cathi(ef_0, ef_1));
-        let y6 = I::mul(w6p, I::catlo(gh_0, gh_1));
-        let y7 = I::mul(w7p, I::cathi(gh_0, gh_1));
-
-        let a04 = I::add(y0, y4);
-        let s04 = I::sub(y0, y4);
-        let a26 = I::add(y2, y6);
-        let js26 = I::xpj(fwd, I::sub(y2, y6));
-        let a15 = I::add(y1, y5);
-        let s15 = I::sub(y1, y5);
-        let a37 = I::add(y3, y7);
-        let js37 = I::xpj(fwd, I::sub(y3, y7));
-
-        let a04_p1_a26 = I::add(a04, a26);
-        let a15_p1_a37 = I::add(a15, a37);
-        I::store(x_p.add(big_n0), I::add(a04_p1_a26, a15_p1_a37));
-        I::store(x_p.add(big_n4), I::sub(a04_p1_a26, a15_p1_a37));
-
-        let s04_mj_s26 = I::sub(s04, js26);
-        let w8_s15_mj_s37 = I::xw8(fwd, I::sub(s15, js37));
-        I::store(x_p.add(big_n1), I::add(s04_mj_s26, w8_s15_mj_s37));
-        I::store(x_p.add(big_n5), I::sub(s04_mj_s26, w8_s15_mj_s37));
-
-        let a04_m1_a26 = I::sub(a04, a26);
-        let j_a15_m1_a37 = I::xpj(fwd, I::sub(a15, a37));
-        I::store(x_p.add(big_n2), I::sub(a04_m1_a26, j_a15_m1_a37));
-        I::store(x_p.add(big_n6), I::add(a04_m1_a26, j_a15_m1_a37));
-
-        let s04_pj_s26 = I::add(s04, js26);
-        let v8_s15_pj_s37 = I::xv8(fwd, I::add(s15, js37));
-        I::store(x_p.add(big_n3), I::sub(s04_pj_s26, v8_s15_pj_s37));
-        I::store(x_p.add(big_n7), I::add(s04_pj_s26, v8_s15_pj_s37));
-
-        p += 2;
-    }
+    // we create a fn pointer that will be force-inlined in release builds
+    // but not in debug builds. this helps keep compile times low, since dead code
+    // elimination handles this well in release builds. and the function pointer indirection
+    // prevents inlining in debug builds.
+    let stockham = if s == 1 && simd.lane_count() == 2 {
+        stockham_core_1x2
+    } else if s == 1 && simd.lane_count() == 4 {
+        stockham_core_1x4
+    } else {
+        stockham_core_generic
+    };
+    stockham(simd, fwd, s, x, y, w_init, w);
 }
 
 #[inline(always)]
-#[allow(dead_code)]
-unsafe fn core_x4<I2: FftSimd64X2, I4: FftSimd64X4>(
+fn last_butterfly<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
     fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    w: *const c64,
-) {
-    debug_assert_eq!(s, 1);
-    if n == 16 {
-        return core_x2::<I2>(fwd, n, s, x, y, w);
-    }
+    x0: c64xN,
+    x1: c64xN,
+    x2: c64xN,
+    x3: c64xN,
+    x4: c64xN,
+    x5: c64xN,
+    x6: c64xN,
+    x7: c64xN,
+) -> (c64xN, c64xN, c64xN, c64xN, c64xN, c64xN, c64xN, c64xN) {
+    let a04 = simd.add(x0, x4);
+    let s04 = simd.sub(x0, x4);
+    let a26 = simd.add(x2, x6);
+    let js26 = simd.mul_j(fwd, simd.sub(x2, x6));
+    let a15 = simd.add(x1, x5);
+    let s15 = simd.sub(x1, x5);
+    let a37 = simd.add(x3, x7);
+    let js37 = simd.mul_j(fwd, simd.sub(x3, x7));
+    let a04_p1_a26 = simd.add(a04, a26);
+    let s04_mj_s26 = simd.sub(s04, js26);
+    let a04_m1_a26 = simd.sub(a04, a26);
+    let s04_pj_s26 = simd.add(s04, js26);
+    let a15_p1_a37 = simd.add(a15, a37);
+    let w8_s15_mj_s37 = simd.mul_exp_neg_pi_over_8(fwd, simd.sub(s15, js37));
+    let j_a15_m1_a37 = simd.mul_j(fwd, simd.sub(a15, a37));
+    let v8_s15_pj_s37 = simd.mul_exp_pi_over_8(fwd, simd.add(s15, js37));
 
-    let big_n = n;
-    let big_n0 = 0;
-    let big_n1 = big_n / 8;
-    let big_n2 = big_n1 * 2;
-    let big_n3 = big_n1 * 3;
-    let big_n4 = big_n1 * 4;
-    let big_n5 = big_n1 * 5;
-    let big_n6 = big_n1 * 6;
-    let big_n7 = big_n1 * 7;
-
-    let mut p = 0;
-    while p < big_n1 {
-        let x_p = x.add(p);
-        let y_8p = y.add(8 * p);
-
-        let w1p = I4::load(twid(8, big_n, 1, w, p));
-        let w2p = I4::load(twid(8, big_n, 2, w, p));
-        let w3p = I4::load(twid(8, big_n, 3, w, p));
-        let w4p = I4::load(twid(8, big_n, 4, w, p));
-        let w5p = I4::load(twid(8, big_n, 5, w, p));
-        let w6p = I4::load(twid(8, big_n, 6, w, p));
-        let w7p = I4::load(twid(8, big_n, 7, w, p));
-
-        let abcd_0 = I4::load(y_8p.add(0));
-        let efgh_0 = I4::load(y_8p.add(4));
-        let abcd_1 = I4::load(y_8p.add(8));
-        let efgh_1 = I4::load(y_8p.add(12));
-        let abcd_2 = I4::load(y_8p.add(16));
-        let efgh_2 = I4::load(y_8p.add(20));
-        let abcd_3 = I4::load(y_8p.add(24));
-        let efgh_3 = I4::load(y_8p.add(28));
-
-        let (a, b, c, d) = I4::transpose(abcd_0, abcd_1, abcd_2, abcd_3);
-        let (e, f, g, h) = I4::transpose(efgh_0, efgh_1, efgh_2, efgh_3);
-
-        let y0 = a;
-        let y1 = I4::mul(w1p, b);
-        let y2 = I4::mul(w2p, c);
-        let y3 = I4::mul(w3p, d);
-        let y4 = I4::mul(w4p, e);
-        let y5 = I4::mul(w5p, f);
-        let y6 = I4::mul(w6p, g);
-        let y7 = I4::mul(w7p, h);
-
-        let a04 = I4::add(y0, y4);
-        let s04 = I4::sub(y0, y4);
-        let a26 = I4::add(y2, y6);
-        let js26 = I4::xpj(fwd, I4::sub(y2, y6));
-        let a15 = I4::add(y1, y5);
-        let s15 = I4::sub(y1, y5);
-        let a37 = I4::add(y3, y7);
-        let js37 = I4::xpj(fwd, I4::sub(y3, y7));
-
-        let a04_p1_a26 = I4::add(a04, a26);
-        let a15_p1_a37 = I4::add(a15, a37);
-        I4::store(x_p.add(big_n0), I4::add(a04_p1_a26, a15_p1_a37));
-        I4::store(x_p.add(big_n4), I4::sub(a04_p1_a26, a15_p1_a37));
-
-        let s04_mj_s26 = I4::sub(s04, js26);
-        let w8_s15_mj_s37 = I4::xw8(fwd, I4::sub(s15, js37));
-        I4::store(x_p.add(big_n1), I4::add(s04_mj_s26, w8_s15_mj_s37));
-        I4::store(x_p.add(big_n5), I4::sub(s04_mj_s26, w8_s15_mj_s37));
-
-        let a04_m1_a26 = I4::sub(a04, a26);
-        let j_a15_m1_a37 = I4::xpj(fwd, I4::sub(a15, a37));
-        I4::store(x_p.add(big_n2), I4::sub(a04_m1_a26, j_a15_m1_a37));
-        I4::store(x_p.add(big_n6), I4::add(a04_m1_a26, j_a15_m1_a37));
-
-        let s04_pj_s26 = I4::add(s04, js26);
-        let v8_s15_pj_s37 = I4::xv8(fwd, I4::add(s15, js37));
-        I4::store(x_p.add(big_n3), I4::sub(s04_pj_s26, v8_s15_pj_s37));
-        I4::store(x_p.add(big_n7), I4::add(s04_pj_s26, v8_s15_pj_s37));
-
-        p += 4;
-    }
-}
-
-#[inline(always)]
-pub(crate) unsafe fn end_8<I: FftSimd64>(
-    fwd: bool,
-    n: usize,
-    s: usize,
-    x: *mut c64,
-    y: *mut c64,
-    eo: bool,
-) {
-    debug_assert_eq!(n, 8);
-    debug_assert_eq!(s % I::COMPLEX_PER_REG, 0);
-
-    let z = if eo { y } else { x };
-
-    let mut q = 0;
-    while q < s {
-        let xq = x.add(q);
-        let zq = z.add(q);
-
-        let z0 = I::load(zq.add(0));
-        let z1 = I::load(zq.add(s));
-        let z2 = I::load(zq.add(s * 2));
-        let z3 = I::load(zq.add(s * 3));
-        let z4 = I::load(zq.add(s * 4));
-        let z5 = I::load(zq.add(s * 5));
-        let z6 = I::load(zq.add(s * 6));
-        let z7 = I::load(zq.add(s * 7));
-        let a04 = I::add(z0, z4);
-        let s04 = I::sub(z0, z4);
-        let a26 = I::add(z2, z6);
-        let js26 = I::xpj(fwd, I::sub(z2, z6));
-        let a15 = I::add(z1, z5);
-        let s15 = I::sub(z1, z5);
-        let a37 = I::add(z3, z7);
-        let js37 = I::xpj(fwd, I::sub(z3, z7));
-        let a04_p1_a26 = I::add(a04, a26);
-        let s04_mj_s26 = I::sub(s04, js26);
-        let a04_m1_a26 = I::sub(a04, a26);
-        let s04_pj_s26 = I::add(s04, js26);
-        let a15_p1_a37 = I::add(a15, a37);
-        let w8_s15_mj_s37 = I::xw8(fwd, I::sub(s15, js37));
-        let j_a15_m1_a37 = I::xpj(fwd, I::sub(a15, a37));
-        let v8_s15_pj_s37 = I::xv8(fwd, I::add(s15, js37));
-        I::store(xq.add(0), I::add(a04_p1_a26, a15_p1_a37));
-        I::store(xq.add(s), I::add(s04_mj_s26, w8_s15_mj_s37));
-        I::store(xq.add(s * 2), I::sub(a04_m1_a26, j_a15_m1_a37));
-        I::store(xq.add(s * 3), I::sub(s04_pj_s26, v8_s15_pj_s37));
-        I::store(xq.add(s * 4), I::sub(a04_p1_a26, a15_p1_a37));
-        I::store(xq.add(s * 5), I::sub(s04_mj_s26, w8_s15_mj_s37));
-        I::store(xq.add(s * 6), I::add(a04_m1_a26, j_a15_m1_a37));
-        I::store(xq.add(s * 7), I::add(s04_pj_s26, v8_s15_pj_s37));
-
-        q += I::COMPLEX_PER_REG;
-    }
-}
-
-macro_rules! dit8_impl {
     (
-        $(
-            $(#[$attr: meta])*
-            pub static $fft: ident = Fft {
-                core_1: $core1______: expr,
-                native: $xn: ty,
-                x1: $x1: ty,
-                $(target: $target: tt,)?
-            };
-        )*
-    ) => {
-        $(
-            #[allow(missing_copy_implementations)]
-            #[allow(non_camel_case_types)]
-            #[allow(dead_code)]
-            $(#[$attr])*
-            struct $fft {
-                __private: (),
-            }
-            #[allow(unused_variables)]
-            #[allow(dead_code)]
-            $(#[$attr])*
-            impl $fft {
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_00<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {}
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_01<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$x1>(FWD, 1 << 1, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_02<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$x1>(FWD, 1 << 2, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_03<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_8::<$x1>(FWD, 1 << 3, 1 << 0, x, y, false);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_04<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 3, y, x, true);
-                    $core1______(FWD, 1 << 4, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_05<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$xn>(FWD, 1 << 2, 1 << 3, y, x, true);
-                    $core1______(FWD, 1 << 5, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_06<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_8::<$xn>(FWD, 1 << 3, 1 << 3, y, x, true);
-                    $core1______(FWD, 1 << 6, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_07<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 1, 1 << 6, x, y, false);
-                    core_::<$xn>(FWD, 1 << 4, 1 << 3, y, x, w);
-                    $core1______(FWD, 1 << 7, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_08<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$xn>(FWD, 1 << 2, 1 << 6, x, y, false);
-                    core_::<$xn>(FWD, 1 << 5, 1 << 3, y, x, w);
-                    $core1______(FWD, 1 << 8, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_09<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_8::<$xn>(FWD, 1 << 3, 1 << 6, x, y, false);
-                    core_::<$xn>(FWD, 1 << 6, 1 << 3, y, x, w);
-                    $core1______(FWD, 1 << 9, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_10<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 01, 1 << 9, y, x, true);
-                    core_::<$xn>(FWD, 1 << 04, 1 << 6, x, y, w);
-                    core_::<$xn>(FWD, 1 << 07, 1 << 3, y, x, w);
-                    $core1______(FWD, 1 << 10, 1 << 0, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_11<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$xn>(FWD, 1 << 02, 1 << 09, y, x, true);
-                    core_::<$xn>(FWD, 1 << 05, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 08, 1 << 03, y, x, w);
-                    $core1______(FWD, 1 << 11, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_12<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_8::<$xn>(FWD, 1 << 03, 1 << 09, y, x, true);
-                    core_::<$xn>(FWD, 1 << 06, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 09, 1 << 03, y, x, w);
-                    $core1______(FWD, 1 << 12, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_13<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 01, 1 << 12, x, y, false);
-                    core_::<$xn>(FWD, 1 << 04, 1 << 09, y, x, w);
-                    core_::<$xn>(FWD, 1 << 07, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 03, y, x, w);
-                    $core1______(FWD, 1 << 13, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_14<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_4::<$xn>(FWD, 1 << 02, 1 << 12, x, y, false);
-                    core_::<$xn>(FWD, 1 << 05, 1 << 09, y, x, w);
-                    core_::<$xn>(FWD, 1 << 08, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 11, 1 << 03, y, x, w);
-                    $core1______(FWD, 1 << 14, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_15<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_8::<$xn>(FWD, 1 << 03, 1 << 12, x, y, false);
-                    core_::<$xn>(FWD, 1 << 06, 1 << 09, y, x, w);
-                    core_::<$xn>(FWD, 1 << 09, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 12, 1 << 03, y, x, w);
-                    $core1______(FWD, 1 << 15, 1 << 00, x, y, w);
-                }
-                $(#[target_feature(enable = $target)])?
-                unsafe fn fft_16<const FWD: bool>(x: *mut c64, y: *mut c64, w: *const c64) {
-                    end_2::<$xn>(FWD, 1 << 01, 1 << 15, y, x, true);
-                    core_::<$xn>(FWD, 1 << 04, 1 << 12, x, y, w);
-                    core_::<$xn>(FWD, 1 << 07, 1 << 09, y, x, w);
-                    core_::<$xn>(FWD, 1 << 10, 1 << 06, x, y, w);
-                    core_::<$xn>(FWD, 1 << 13, 1 << 03, y, x, w);
-                    $core1______(FWD, 1 << 16, 1 << 00, x, y, w);
-                }
-            }
-            $(#[$attr])*
-            pub(crate) static $fft: crate::FftImpl = crate::FftImpl {
-                fwd: [
-                    <$fft>::fft_00::<true>,
-                    <$fft>::fft_01::<true>,
-                    <$fft>::fft_02::<true>,
-                    <$fft>::fft_03::<true>,
-                    <$fft>::fft_04::<true>,
-                    <$fft>::fft_05::<true>,
-                    <$fft>::fft_06::<true>,
-                    <$fft>::fft_07::<true>,
-                    <$fft>::fft_08::<true>,
-                    <$fft>::fft_09::<true>,
-                    <$fft>::fft_10::<true>,
-                    <$fft>::fft_11::<true>,
-                    <$fft>::fft_12::<true>,
-                    <$fft>::fft_13::<true>,
-                    <$fft>::fft_14::<true>,
-                    <$fft>::fft_15::<true>,
-                    <$fft>::fft_16::<true>,
-                ],
-                inv: [
-                    <$fft>::fft_00::<false>,
-                    <$fft>::fft_01::<false>,
-                    <$fft>::fft_02::<false>,
-                    <$fft>::fft_03::<false>,
-                    <$fft>::fft_04::<false>,
-                    <$fft>::fft_05::<false>,
-                    <$fft>::fft_06::<false>,
-                    <$fft>::fft_07::<false>,
-                    <$fft>::fft_08::<false>,
-                    <$fft>::fft_09::<false>,
-                    <$fft>::fft_10::<false>,
-                    <$fft>::fft_11::<false>,
-                    <$fft>::fft_12::<false>,
-                    <$fft>::fft_13::<false>,
-                    <$fft>::fft_14::<false>,
-                    <$fft>::fft_15::<false>,
-                    <$fft>::fft_16::<false>,
-                ],
-            };
-            )*
-    };
+        simd.add(a04_p1_a26, a15_p1_a37),
+        simd.add(s04_mj_s26, w8_s15_mj_s37),
+        simd.sub(a04_m1_a26, j_a15_m1_a37),
+        simd.sub(s04_pj_s26, v8_s15_pj_s37),
+        simd.sub(a04_p1_a26, a15_p1_a37),
+        simd.sub(s04_mj_s26, w8_s15_mj_s37),
+        simd.add(a04_m1_a26, j_a15_m1_a37),
+        simd.add(s04_pj_s26, v8_s15_pj_s37),
+    )
 }
 
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-use crate::x86::*;
+#[inline(always)]
+pub fn stockham_dit8_end<c64xN: Pod>(
+    simd: impl FftSimd<c64xN>,
+    fwd: bool,
+    read_from_x: bool,
+    s: usize,
+    x: &mut [c64xN],
+    y: &mut [c64xN],
+) {
+    assert_eq!(s % simd.lane_count(), 0);
+    let (x0, x1, x2, x3, x4, x5, x6, x7) = split_mut_8(x);
+    let (y0, y1, y2, y3, y4, y5, y6, y7) = split_mut_8(y);
 
-dit8_impl! {
-    pub static DIT8_SCALAR = Fft {
-        core_1: core_::<Scalar>,
-        native: Scalar,
-        x1: Scalar,
-    };
+    // we create a fn pointer that will be force-inlined in release builds
+    // but not in debug builds. this helps keep compile times low, since dead code
+    // elimination handles this well in release builds. and the function pointer indirection
+    // prevents inlining in debug builds.
+    let last_butterfly: fn(_, _, _, _, _, _, _, _, _, _) -> _ = last_butterfly;
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub static DIT8_AVX = Fft {
-        core_1: core_x2::<AvxX2>,
-        native: AvxX2,
-        x1: AvxX1,
-        target: "avx",
-    };
-
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub static DIT8_FMA = Fft {
-        core_1: core_x2::<FmaX2>,
-        native: FmaX2,
-        x1: FmaX1,
-        target: "fma",
-    };
-
-    #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
-    pub static DIT8_AVX512 = Fft {
-        core_1: core_x4::<Avx512X2, Avx512X4>,
-        native: Avx512X4,
-        x1: Avx512X1,
-        target: "avx512f",
-    };
+    if read_from_x {
+        for (x0, x1, x2, x3, x4, x5, x6, x7) in izip!(x0, x1, x2, x3, x4, x5, x6, x7) {
+            (*x0, *x1, *x2, *x3, *x4, *x5, *x6, *x7) =
+                last_butterfly(simd, fwd, *x0, *x1, *x2, *x3, *x4, *x5, *x6, *x7);
+        }
+    } else {
+        for ((x0, x1, x2, x3, x4, x5, x6, x7), (y0, y1, y2, y3, y4, y5, y6, y7)) in izip!(
+            izip!(x0, x1, x2, x3, x4, x5, x6, x7),
+            izip!(y0, y1, y2, y3, y4, y5, y6, y7),
+        ) {
+            (*x0, *x1, *x2, *x3, *x4, *x5, *x6, *x7) =
+                last_butterfly(simd, fwd, *y0, *y1, *y2, *y3, *y4, *y5, *y6, *y7);
+        }
+    }
 }
 
-pub(crate) fn runtime_fft() -> crate::FftImpl {
-    #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
-    if x86_feature_detected!("avx512f") {
-        return DIT8_AVX512;
-    }
+struct Dit8<N: nat::Nat>(N);
+impl<N: nat::Nat> nat::Nat for Dit8<N> {
+    const VALUE: usize = N::VALUE;
+}
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    if x86_feature_detected!("fma") {
-        return DIT8_FMA;
-    } else if x86_feature_detected!("avx") {
-        return DIT8_AVX;
+// size 2
+impl RecursiveFft for Dit8<nat::N0> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        read_from_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        crate::dit2::stockham_dit2_end(simd, fwd, read_from_x, s, x, y);
     }
+}
 
-    DIT8_SCALAR
+// size 4
+impl RecursiveFft for Dit8<nat::N1> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        read_from_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        crate::dit4::stockham_dit4_end(simd, fwd, read_from_x, s, x, y);
+    }
+}
+
+// size 8
+impl RecursiveFft for Dit8<nat::N2> {
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        read_from_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        _w_init: &[c64xN],
+        _w: &[c64],
+    ) {
+        stockham_dit8_end(simd, fwd, read_from_x, s, x, y);
+    }
+}
+
+impl<N: nat::Nat> RecursiveFft for Dit8<nat::Plus3<N>>
+where
+    Dit8<N>: RecursiveFft,
+{
+    #[inline(always)]
+    fn fft_recurse_impl<c64xN: Pod>(
+        simd: impl FftSimd<c64xN>,
+        fwd: bool,
+        read_from_x: bool,
+        s: usize,
+        x: &mut [c64xN],
+        y: &mut [c64xN],
+        w_init: &[c64xN],
+        w: &[c64],
+    ) {
+        Dit8::<N>::fft_recurse_impl(simd, fwd, !read_from_x, s * 8, y, x, w_init, w);
+        stockham_core(simd, fwd, s, x, y, w_init, w);
+    }
+}
+
+pub(crate) fn fft_impl<c64xN: Pod>(simd: impl FftSimd<c64xN>) -> crate::FftImpl {
+    let fwd = [
+        fn_ptr::<true, Dit8<nat::N0>, _, _>(simd),
+        fn_ptr::<true, Dit8<nat::N1>, _, _>(simd),
+        fn_ptr::<true, Dit8<nat::N2>, _, _>(simd),
+        fn_ptr::<true, Dit8<nat::N3>, _, _>(simd),
+        fn_ptr::<true, Dit8<nat::N4>, _, _>(simd),
+        fn_ptr::<true, Dit8<nat::N5>, _, _>(simd),
+        fn_ptr::<true, Dit8<nat::N6>, _, _>(simd),
+        fn_ptr::<true, Dit8<nat::N7>, _, _>(simd),
+        fn_ptr::<true, Dit8<nat::N8>, _, _>(simd),
+        fn_ptr::<true, Dit8<nat::N9>, _, _>(simd),
+    ];
+    let inv = [
+        fn_ptr::<false, Dit8<nat::N0>, _, _>(simd),
+        fn_ptr::<false, Dit8<nat::N1>, _, _>(simd),
+        fn_ptr::<false, Dit8<nat::N2>, _, _>(simd),
+        fn_ptr::<false, Dit8<nat::N3>, _, _>(simd),
+        fn_ptr::<false, Dit8<nat::N4>, _, _>(simd),
+        fn_ptr::<false, Dit8<nat::N5>, _, _>(simd),
+        fn_ptr::<false, Dit8<nat::N6>, _, _>(simd),
+        fn_ptr::<false, Dit8<nat::N7>, _, _>(simd),
+        fn_ptr::<false, Dit8<nat::N8>, _, _>(simd),
+        fn_ptr::<false, Dit8<nat::N9>, _, _>(simd),
+    ];
+    crate::FftImpl { fwd, inv }
+}
+
+pub fn fft_impl_dispatch(n: usize) -> [fn(&mut [c64], &mut [c64], &[c64], &[c64]); 2] {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        #[cfg(feature = "nightly")]
+        if let Some(simd) = pulp::x86::V4::try_new() {
+            if n >= 8 * simd.lane_count() {
+                return fft_impl(simd).make_fn_ptr(n);
+            }
+        }
+        if let Some(simd) = pulp::x86::V3::try_new() {
+            if n >= 8 * simd.lane_count() {
+                return fft_impl(simd).make_fn_ptr(n);
+            }
+        }
+    }
+    fft_impl(crate::fft_simd::Scalar).make_fn_ptr(n)
 }

--- a/src/nat.rs
+++ b/src/nat.rs
@@ -1,0 +1,28 @@
+pub struct Successor<N>(pub N);
+pub struct Zero;
+pub type N0 = Zero;
+pub type N1 = Successor<N0>;
+pub type N2 = Successor<N1>;
+pub type N3 = Successor<N2>;
+pub type N4 = Successor<N3>;
+pub type N5 = Successor<N4>;
+pub type N6 = Successor<N5>;
+pub type N7 = Successor<N6>;
+pub type N8 = Successor<N7>;
+pub type N9 = Successor<N8>;
+
+pub trait Nat {
+    const VALUE: usize;
+}
+
+impl Nat for Zero {
+    const VALUE: usize = 0;
+}
+impl<N: Nat> Nat for Successor<N> {
+    const VALUE: usize = N::VALUE + 1;
+}
+
+pub type Plus1<N> = Successor<N>;
+pub type Plus2<N> = Successor<Plus1<N>>;
+pub type Plus3<N> = Successor<Plus2<N>>;
+pub type Plus4<N> = Successor<Plus3<N>>;

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -1,376 +1,154 @@
-use crate::c64;
-use crate::fft_simd::{FftSimd64, FftSimd64X2};
+use crate::{c64, fft_simd::*};
+use pulp::{cast, x86::*};
 
-#[cfg(target_arch = "x86")]
-use core::arch::x86::*;
-
-#[cfg(target_arch = "x86_64")]
-use core::arch::x86_64::*;
-
-#[derive(Copy, Clone, Debug)]
-pub struct AvxX2;
-#[derive(Copy, Clone, Debug)]
-pub struct AvxX1;
-
-#[derive(Copy, Clone, Debug)]
-pub struct FmaX2;
-#[derive(Copy, Clone, Debug)]
-pub struct FmaX1;
-
-#[cfg(feature = "nightly")]
-pub struct Avx512X4;
-#[cfg(feature = "nightly")]
-pub struct Avx512X2;
-#[cfg(feature = "nightly")]
-pub struct Avx512X1;
-
-macro_rules! reimpl {
-    (
-        as $ty: ty:
-        $(
-            unsafe fn $name: ident($($arg_name: ident: $arg_ty: ty),* $(,)?) $(-> $ret: ty)?;
-        )*
-    ) => {
-        $(
-            #[inline(always)]
-            unsafe fn $name($($arg_name: $arg_ty),*) $(-> $ret)? {
-                <$ty>::$name($($arg_name),*)
-            }
-        )*
-    };
-}
-
-impl FftSimd64 for AvxX1 {
-    type Reg = __m128d;
-
-    const COMPLEX_PER_REG: usize = 1;
-
+impl FftSimd<c64x2> for V3 {
     #[inline(always)]
-    unsafe fn splat_re_im(ptr: *const f64) -> Self::Reg {
-        _mm_set1_pd(*ptr)
+    fn try_new() -> Option<Self> {
+        Self::try_new()
+    }
+    #[inline(always)]
+    fn vectorize(self, f: impl pulp::NullaryFnOnce<Output = ()>) {
+        self.vectorize(f)
     }
 
     #[inline(always)]
-    unsafe fn splat(ptr: *const crate::c64) -> Self::Reg {
-        Self::load(ptr)
+    fn splat_f64(self, value: f64) -> c64x2 {
+        cast(self.splat_f64x4(value))
     }
 
     #[inline(always)]
-    unsafe fn load(ptr: *const crate::c64) -> Self::Reg {
-        _mm_loadu_pd(ptr as _)
+    fn splat(self, value: c64) -> c64x2 {
+        let f128 = cast(value);
+        cast(self.avx._mm256_broadcast_pd(&f128))
     }
 
     #[inline(always)]
-    unsafe fn store(ptr: *mut crate::c64, z: Self::Reg) {
-        _mm_storeu_pd(ptr as _, z);
+    fn xor(self, a: c64x2, b: c64x2) -> c64x2 {
+        cast(self.xor_f64x4(cast(a), cast(b)))
     }
 
     #[inline(always)]
-    unsafe fn xor(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm_xor_pd(a, b)
+    fn swap_re_im(self, xy: c64x2) -> c64x2 {
+        cast(self.avx._mm256_permute_pd::<0b0101>(cast(xy)))
     }
 
     #[inline(always)]
-    unsafe fn swap_re_im(xy: Self::Reg) -> Self::Reg {
-        _mm_permute_pd::<0b01>(xy)
+    fn add(self, a: c64x2, b: c64x2) -> c64x2 {
+        cast(self.add_f64x4(cast(a), cast(b)))
     }
 
     #[inline(always)]
-    unsafe fn add(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm_add_pd(a, b)
+    fn sub(self, a: c64x2, b: c64x2) -> c64x2 {
+        cast(self.sub_f64x4(cast(a), cast(b)))
     }
 
     #[inline(always)]
-    unsafe fn sub(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm_sub_pd(a, b)
+    fn real_mul(self, a: c64x2, b: c64x2) -> c64x2 {
+        cast(self.mul_f64x4(cast(a), cast(b)))
     }
 
     #[inline(always)]
-    unsafe fn cwise_mul(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm_mul_pd(a, b)
+    fn mul(self, a: c64x2, b: c64x2) -> c64x2 {
+        let xy = cast(b);
+        let yx = cast(self.swap_re_im(b));
+        let ab = cast(a);
+        let aa = cast(self.avx._mm256_unpacklo_pd(ab, ab));
+        let bb = cast(self.avx._mm256_unpackhi_pd(ab, ab));
+        cast(self.mul_subadd_f64x4(aa, xy, self.mul_f64x4(bb, yx)))
+    }
+    #[inline(always)]
+    fn catlo(self, a: c64x2, b: c64x2) -> c64x2 {
+        cast(
+            self.avx
+                ._mm256_permute2f128_pd::<0b0010_0000>(cast(a), cast(b)),
+        )
     }
 
     #[inline(always)]
-    unsafe fn mul(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        let ab = a;
-        let xy = b;
-        let aa = _mm_unpacklo_pd(ab, ab);
-        let bb = _mm_unpackhi_pd(ab, ab);
-        let yx = Self::swap_re_im(xy);
-        _mm_addsub_pd(_mm_mul_pd(aa, xy), _mm_mul_pd(bb, yx))
-    }
-}
-
-impl FftSimd64 for AvxX2 {
-    type Reg = __m256d;
-
-    const COMPLEX_PER_REG: usize = 2;
-
-    #[inline(always)]
-    unsafe fn splat_re_im(ptr: *const f64) -> Self::Reg {
-        _mm256_set1_pd(*ptr)
-    }
-
-    #[inline(always)]
-    unsafe fn splat(ptr: *const crate::c64) -> Self::Reg {
-        let tmp = _mm_loadu_pd(ptr as _);
-        _mm256_broadcast_pd(&tmp)
-    }
-
-    #[inline(always)]
-    unsafe fn load(ptr: *const crate::c64) -> Self::Reg {
-        _mm256_loadu_pd(ptr as _)
-    }
-
-    #[inline(always)]
-    unsafe fn store(ptr: *mut crate::c64, z: Self::Reg) {
-        _mm256_storeu_pd(ptr as _, z);
-    }
-
-    #[inline(always)]
-    unsafe fn xor(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm256_xor_pd(a, b)
-    }
-
-    #[inline(always)]
-    unsafe fn swap_re_im(xy: Self::Reg) -> Self::Reg {
-        _mm256_permute_pd::<0b0101>(xy)
-    }
-
-    #[inline(always)]
-    unsafe fn add(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm256_add_pd(a, b)
-    }
-
-    #[inline(always)]
-    unsafe fn sub(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm256_sub_pd(a, b)
-    }
-
-    #[inline(always)]
-    unsafe fn cwise_mul(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm256_mul_pd(a, b)
-    }
-
-    #[inline(always)]
-    unsafe fn mul(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        let ab = a;
-        let xy = b;
-        let aa = _mm256_unpacklo_pd(ab, ab);
-        let bb = _mm256_unpackhi_pd(ab, ab);
-        let yx = Self::swap_re_im(xy);
-        _mm256_addsub_pd(_mm256_mul_pd(aa, xy), _mm256_mul_pd(bb, yx))
-    }
-}
-
-impl FftSimd64 for FmaX1 {
-    type Reg = __m128d;
-
-    const COMPLEX_PER_REG: usize = 1;
-
-    reimpl! { as AvxX1:
-        unsafe fn splat_re_im(ptr: *const f64) -> Self::Reg;
-        unsafe fn splat(ptr: *const c64) -> Self::Reg;
-        unsafe fn load(ptr: *const c64) -> Self::Reg;
-        unsafe fn store(ptr: *mut c64, z: Self::Reg);
-        unsafe fn xor(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn swap_re_im(xy: Self::Reg) -> Self::Reg;
-        unsafe fn add(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn sub(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn cwise_mul(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-    }
-
-    #[inline(always)]
-    unsafe fn mul(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        let ab = a;
-        let xy = b;
-        let aa = _mm_unpacklo_pd(ab, ab);
-        let bb = _mm_unpackhi_pd(ab, ab);
-        let yx = Self::swap_re_im(xy);
-        _mm_fmaddsub_pd(aa, xy, _mm_mul_pd(bb, yx))
-    }
-}
-
-impl FftSimd64 for FmaX2 {
-    type Reg = __m256d;
-
-    const COMPLEX_PER_REG: usize = 2;
-
-    reimpl! { as AvxX2:
-        unsafe fn splat_re_im(ptr: *const f64) -> Self::Reg;
-        unsafe fn splat(ptr: *const c64) -> Self::Reg;
-        unsafe fn load(ptr: *const c64) -> Self::Reg;
-        unsafe fn store(ptr: *mut c64, z: Self::Reg);
-        unsafe fn xor(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn swap_re_im(xy: Self::Reg) -> Self::Reg;
-        unsafe fn add(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn sub(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn cwise_mul(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-    }
-
-    #[inline(always)]
-    unsafe fn mul(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        let ab = a;
-        let xy = b;
-        let aa = _mm256_unpacklo_pd(ab, ab);
-        let bb = _mm256_unpackhi_pd(ab, ab);
-        let yx = Self::swap_re_im(xy);
-        _mm256_fmaddsub_pd(aa, xy, _mm256_mul_pd(bb, yx))
+    fn cathi(self, a: c64x2, b: c64x2) -> c64x2 {
+        cast(
+            self.avx
+                ._mm256_permute2f128_pd::<0b0011_0001>(cast(a), cast(b)),
+        )
     }
 }
 
 #[cfg(feature = "nightly")]
-impl FftSimd64 for Avx512X1 {
-    type Reg = __m128d;
-
-    const COMPLEX_PER_REG: usize = 1;
-
-    reimpl! { as FmaX1:
-        unsafe fn splat_re_im(ptr: *const f64) -> Self::Reg;
-        unsafe fn splat(ptr: *const c64) -> Self::Reg;
-        unsafe fn load(ptr: *const c64) -> Self::Reg;
-        unsafe fn store(ptr: *mut c64, z: Self::Reg);
-        unsafe fn xor(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn swap_re_im(xy: Self::Reg) -> Self::Reg;
-        unsafe fn add(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn sub(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn cwise_mul(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn mul(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl FftSimd64 for Avx512X2 {
-    type Reg = __m256d;
-
-    const COMPLEX_PER_REG: usize = 2;
-
-    reimpl! { as FmaX2:
-        unsafe fn splat_re_im(ptr: *const f64) -> Self::Reg;
-        unsafe fn splat(ptr: *const c64) -> Self::Reg;
-        unsafe fn load(ptr: *const c64) -> Self::Reg;
-        unsafe fn store(ptr: *mut c64, z: Self::Reg);
-        unsafe fn xor(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn swap_re_im(xy: Self::Reg) -> Self::Reg;
-        unsafe fn add(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn sub(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn cwise_mul(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn mul(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl FftSimd64 for Avx512X4 {
-    type Reg = __m512d;
-
-    const COMPLEX_PER_REG: usize = 4;
-
+impl FftSimd<c64x4> for V4 {
     #[inline(always)]
-    unsafe fn splat_re_im(ptr: *const f64) -> Self::Reg {
-        _mm512_set1_pd(*ptr)
+    fn try_new() -> Option<Self> {
+        Self::try_new()
+    }
+    #[inline(always)]
+    fn vectorize(self, f: impl pulp::NullaryFnOnce<Output = ()>) {
+        self.vectorize(f)
     }
 
     #[inline(always)]
-    unsafe fn splat(ptr: *const crate::c64) -> Self::Reg {
-        _mm512_castps_pd(_mm512_broadcast_f32x4(_mm_castpd_ps(_mm_loadu_pd(
-            ptr as _,
-        ))))
+    fn splat_f64(self, value: f64) -> c64x4 {
+        cast(self.splat_f64x8(value))
     }
 
     #[inline(always)]
-    unsafe fn load(ptr: *const crate::c64) -> Self::Reg {
-        _mm512_loadu_pd(ptr as _)
+    fn splat(self, value: c64) -> c64x4 {
+        let f128 = cast(value);
+        cast(self.avx512f._mm512_broadcast_f32x4(f128))
     }
 
     #[inline(always)]
-    unsafe fn store(ptr: *mut crate::c64, z: Self::Reg) {
-        _mm512_storeu_pd(ptr as _, z);
+    fn xor(self, a: c64x4, b: c64x4) -> c64x4 {
+        cast(self.xor_f64x8(cast(a), cast(b)))
     }
 
     #[inline(always)]
-    unsafe fn xor(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm512_castsi512_pd(_mm512_xor_si512(
-            _mm512_castpd_si512(a),
-            _mm512_castpd_si512(b),
-        ))
+    fn swap_re_im(self, xy: c64x4) -> c64x4 {
+        cast(self.avx512f._mm512_permute_pd::<0b0101_0101>(cast(xy)))
     }
 
     #[inline(always)]
-    unsafe fn swap_re_im(xy: Self::Reg) -> Self::Reg {
-        _mm512_permute_pd::<0b01010101>(xy)
+    fn add(self, a: c64x4, b: c64x4) -> c64x4 {
+        cast(self.add_f64x8(cast(a), cast(b)))
     }
 
     #[inline(always)]
-    unsafe fn add(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm512_add_pd(a, b)
+    fn sub(self, a: c64x4, b: c64x4) -> c64x4 {
+        cast(self.sub_f64x8(cast(a), cast(b)))
     }
 
     #[inline(always)]
-    unsafe fn sub(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm512_sub_pd(a, b)
+    fn real_mul(self, a: c64x4, b: c64x4) -> c64x4 {
+        cast(self.mul_f64x8(cast(a), cast(b)))
     }
 
     #[inline(always)]
-    unsafe fn cwise_mul(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm512_mul_pd(a, b)
+    fn mul(self, a: c64x4, b: c64x4) -> c64x4 {
+        let xy = cast(b);
+        let yx = cast(self.swap_re_im(b));
+        let ab = cast(a);
+        let aa = cast(self.avx512f._mm512_unpacklo_pd(ab, ab));
+        let bb = cast(self.avx512f._mm512_unpackhi_pd(ab, ab));
+        cast(self.mul_subadd_f64x8(aa, xy, self.mul_f64x8(bb, yx)))
     }
 
     #[inline(always)]
-    unsafe fn mul(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        let ab = a;
-        let xy = b;
-        let aa = _mm512_unpacklo_pd(ab, ab);
-        let bb = _mm512_unpackhi_pd(ab, ab);
-        let yx = Self::swap_re_im(xy);
-        _mm512_fmaddsub_pd(aa, xy, _mm512_mul_pd(bb, yx))
-    }
-}
+    fn transpose(self, r0: c64x4, r1: c64x4, r2: c64x4, r3: c64x4) -> (c64x4, c64x4, c64x4, c64x4) {
+        let t0 = self
+            .avx512f
+            ._mm512_shuffle_f64x2::<0b1000_1000>(cast(r0), cast(r1));
+        let t1 = self
+            .avx512f
+            ._mm512_shuffle_f64x2::<0b1101_1101>(cast(r0), cast(r1));
+        let t2 = self
+            .avx512f
+            ._mm512_shuffle_f64x2::<0b1000_1000>(cast(r2), cast(r3));
+        let t3 = self
+            .avx512f
+            ._mm512_shuffle_f64x2::<0b1101_1101>(cast(r2), cast(r3));
 
-impl FftSimd64X2 for AvxX2 {
-    #[inline(always)]
-    unsafe fn catlo(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm256_permute2f128_pd::<0b00100000>(a, b)
-    }
-
-    #[inline(always)]
-    unsafe fn cathi(a: Self::Reg, b: Self::Reg) -> Self::Reg {
-        _mm256_permute2f128_pd::<0b00110001>(a, b)
-    }
-}
-
-impl FftSimd64X2 for FmaX2 {
-    reimpl! { as AvxX2:
-        unsafe fn catlo(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn cathi(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl FftSimd64X2 for Avx512X2 {
-    reimpl! { as AvxX2:
-        unsafe fn catlo(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-        unsafe fn cathi(a: Self::Reg, b: Self::Reg) -> Self::Reg;
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl crate::fft_simd::FftSimd64X4 for Avx512X4 {
-    #[inline(always)]
-    unsafe fn transpose(
-        r0: Self::Reg,
-        r1: Self::Reg,
-        r2: Self::Reg,
-        r3: Self::Reg,
-    ) -> (Self::Reg, Self::Reg, Self::Reg, Self::Reg) {
-        let t0 = _mm512_shuffle_f64x2::<0b10001000>(r0, r1);
-        let t1 = _mm512_shuffle_f64x2::<0b11011101>(r0, r1);
-        let t2 = _mm512_shuffle_f64x2::<0b10001000>(r2, r3);
-        let t3 = _mm512_shuffle_f64x2::<0b11011101>(r2, r3);
-
-        let s0 = _mm512_shuffle_f64x2::<0b10001000>(t0, t2);
-        let s1 = _mm512_shuffle_f64x2::<0b11011101>(t0, t2);
-        let s2 = _mm512_shuffle_f64x2::<0b10001000>(t1, t3);
-        let s3 = _mm512_shuffle_f64x2::<0b11011101>(t1, t3);
+        let s0 = cast(self.avx512f._mm512_shuffle_f64x2::<0b1000_1000>(t0, t2));
+        let s1 = cast(self.avx512f._mm512_shuffle_f64x2::<0b1101_1101>(t0, t2));
+        let s2 = cast(self.avx512f._mm512_shuffle_f64x2::<0b1000_1000>(t1, t3));
+        let s3 = cast(self.avx512f._mm512_shuffle_f64x2::<0b1101_1101>(t1, t3));
 
         (s0, s2, s1, s3)
     }


### PR DESCRIPTION
this is essentially a full rewrite of `concrete-fft`.  
by depending on the [bytemuck](https://docs.rs/bytemuck/latest/bytemuck/) crate (which is a very lightweight and heavily tested dependency), and with the new `PodStack` abstraction from dyn-stack (which we already depend on) to avoid dealing with uninitialized memory, we can avoid over 99% of the unsafe code usage in `concrete-fft`.