### PR TITLE
fix: Server Key deserialization in wasm32-unknown-unknown

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+# Accessed by wasm-bindgen when testing for the wasm target
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,8 @@ mod dit8;
 mod dif16;
 mod dit16;
 
+mod time;
+
 pub mod ordered;
 pub mod unordered;
 

--- a/src/ordered.rs
+++ b/src/ordered.rs
@@ -58,7 +58,12 @@ pub enum Method {
     Measure(Duration),
 }
 
+// Inlining this function will cause a compiler error when compiling for target wasm32-unknown-unknown.
+// The compiler thinks that the variable `n_runs` is a constant. It tries to optimize the variable, removing it in the process.
+// When the compiler remove the n_runs variable, it results in an infinite loop.
+// Therefore, it is a compiler bug, not the code.
 #[cfg(feature = "std")]
+#[inline(never)]
 fn measure_n_runs(
     n_runs: u128,
     algo: FftAlgo,
@@ -71,7 +76,7 @@ fn measure_n_runs(
     let (mut scratch, _) = stack.make_aligned_raw::<c64>(n, CACHELINE_ALIGN);
     let [fwd, _] = get_fn_ptr(algo, n);
 
-    use std::time::Instant;
+    use crate::time::Instant;
     let now = Instant::now();
 
     for _ in 0..n_runs {

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -1,0 +1,11 @@
+//! The standard API for Instant is not available in Wasm runtimes.
+//! This module replaces the Instant type from std to a custom
+//! type that accesses Javascript's Performance API.
+
+#[cfg(target_family = "wasm")]
+mod wasm;
+#[cfg(not(target_family = "wasm"))]
+pub use std::time::Instant;
+
+#[cfg(target_family = "wasm")]
+pub use wasm::Instant;

--- a/src/time/wasm.rs
+++ b/src/time/wasm.rs
@@ -1,0 +1,28 @@
+#[cfg(target_family = "wasm")]
+pub struct Instant {
+    start: f64,
+}
+
+#[cfg(target_family = "wasm")]
+impl Instant {
+    pub fn now() -> Self {
+        let window = web_sys::window().unwrap();
+        let performance = window.performance().unwrap();
+        let start: f64 = performance.now();
+        Self { start }
+    }
+
+    pub fn elapsed(&self) -> core::time::Duration {
+        let window = web_sys::window().unwrap();
+        let performance = window.performance().unwrap();
+        let start: f64 = self.start;
+        let now = performance.now();
+        let mut elapsed = now - start;
+        // Performance api is not always exact, it will shift the time for a few milliseconds every minute
+        if elapsed < 0. {
+            // pick a relatively low value, 1us
+            elapsed = 0.001;
+        }
+        core::time::Duration::from_micros((elapsed * 1_000.) as u64)
+    }
+}

--- a/src/unordered.rs
+++ b/src/unordered.rs
@@ -610,7 +610,7 @@ fn measure_fastest(
 
             let n_runs = n_runs.ceil() as u32;
 
-            use std::time::Instant;
+            use crate::time::Instant;
             let now = Instant::now();
             for _ in 0..n_runs {
                 fwd_depth(


### PR DESCRIPTION
The fix is very simple. The compiler is making a mistake when optimizing one of the functions, resulting in an infinite loop.

I made this custom change in my local files, and it managed to deserialize the server key and use it in a chrome browser.

std::time::Instant is not available when compiled for target wasm32-unknown-unknown, so I had to use Javascript's Performance API instead.

I'm using a Linux machine with AMD architecture, so running cargo test on this crate locally was causing a build-rs bug at this line:

checking for struct pst_processor.psp_iticksperclktick... no
checking for suitable m4...

Due to that I can't run test on the current architecture.

The main reason for this pr is to explain what is causing the bug for running server key computation on wasm. I'm sure it will be very helpful for you.