### PR TITLE
feat: wasm support and tests

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+# Accessed by wasm-bindgen when testing for the wasm target
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,16 +26,24 @@ std = ["pulp/std"]
 serde = ["dep:serde", "num-complex/serde"]
 
 [dev-dependencies]
-criterion = "0.4"
 rustfft = "6.0"
-fftw-sys = { version = "0.6", default-features = false, features = ["system"] }
-rand = "0.8"
 bincode = "1.3"
 more-asserts = "0.3.1"
 serde_json = "1.0.96"
+wasm-bindgen-test = "0.3"
+wasm-bindgen = "0.2.92"
 
-[target.'cfg(not(target_os = "windows"))'.dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3.69"
+
+[target.'cfg(all(not(target_os = "windows"), not(target_arch = "wasm32")))'.dev-dependencies]
 rug = "1.19.1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+fftw-sys = { version = "0.6", default-features = false, features = ["system"] }
+rand = "0.8"
+criterion = "0.4"
+
 
 [[bench]]
 name = "fft"

--- a/src/fft128/f128_ops.rs
+++ b/src/fft128/f128_ops.rs
@@ -1021,7 +1021,7 @@ pub mod x86 {
     }
 }
 
-#[cfg(all(test, not(target_os = "windows")))]
+#[cfg(all(test, not(target_os = "windows"), not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use more_asserts::assert_le;

--- a/src/fft128/mod.rs
+++ b/src/fft128/mod.rs
@@ -1960,7 +1960,7 @@ impl Plan {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use alloc::vec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ macro_rules! izip {
 
 mod fft_simd;
 mod nat;
+pub mod time;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86;

--- a/src/ordered.rs
+++ b/src/ordered.rs
@@ -59,6 +59,7 @@ pub enum Method {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(target_family = "wasm", inline(never))]
 fn measure_n_runs(
     n_runs: u128,
     algo: FftAlgo,
@@ -71,7 +72,7 @@ fn measure_n_runs(
     let (mut scratch, _) = stack.make_aligned_raw::<c64>(n, CACHELINE_ALIGN);
     let [fwd, _] = get_fn_ptr(algo, n);
 
-    use std::time::Instant;
+    use crate::time::Instant;
     let now = Instant::now();
 
     for _ in 0..n_runs {
@@ -151,7 +152,7 @@ pub(crate) fn measure_fastest(
                     stack.rb_mut(),
                 );
 
-                if duration < MIN_DURATION {
+                if duration <= MIN_DURATION {
                     n_runs *= 2;
                 } else {
                     break (n_runs, duration_div_f64(duration, n_runs as f64));
@@ -378,7 +379,7 @@ impl Plan {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use crate::{
         c64, dif16, dif2, dif4, dif8, dit16, dit2, dit4, dit8,

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -1,0 +1,9 @@
+//! The standard API for Instant is not available in Wasm runtimes.
+//! This module replaces the Instant type from std to a custom implementation.
+
+mod wasm;
+#[cfg(not(target_family = "wasm"))]
+pub use std::time::Instant;
+
+#[cfg(target_family = "wasm")]
+pub use wasm::Instant;

--- a/src/time/wasm.rs
+++ b/src/time/wasm.rs
@@ -1,0 +1,23 @@
+#[cfg(target_family = "wasm")]
+pub struct Instant {
+    start: f64,
+}
+
+#[cfg(target_family = "wasm")]
+impl Instant {
+    pub fn now() -> Self {
+        let now = js_sys::Date::new_0().get_time();
+        Self { start: now }
+    }
+
+    pub fn elapsed(&self) -> core::time::Duration {
+        let start: f64 = self.start;
+        let now = js_sys::Date::new_0().get_time();
+
+        let mut elapsed = now - start;
+        if elapsed < 0. {
+            elapsed = 0.00001;
+        }
+        core::time::Duration::from_micros((elapsed * 1_000.) as u64)
+    }
+}

--- a/src/unordered.rs
+++ b/src/unordered.rs
@@ -610,7 +610,7 @@ fn measure_fastest(
 
             let n_runs = n_runs.ceil() as u32;
 
-            use std::time::Instant;
+            use crate::time::Instant;
             let now = Instant::now();
             for _ in 0..n_runs {
                 fwd_depth(
@@ -1057,7 +1057,7 @@ fn bit_rev_twice_inv(nbits: u32, base_nbits: u32, i: usize) -> usize {
     bit_rev(nbits, i_rev)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use alloc::vec;
@@ -9391,7 +9391,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "serde"))]
+#[cfg(all(test, feature = "serde", not(target_arch = "wasm32")))]
 mod tests_serde {
     use super::*;
     use alloc::{vec, vec::Vec};

--- a/tests/browser.rs
+++ b/tests/browser.rs
@@ -1,0 +1,18 @@
+use wasm_bindgen_test::wasm_bindgen_test_configure;
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test::wasm_bindgen_test]
+pub fn measure_n_runs_infinite_loop() {
+    use concrete_fft::c64;
+    use concrete_fft::unordered::{Method, Plan};
+    use core::time::Duration;
+    use dyn_stack::{GlobalPodBuffer, PodStack};
+
+    let plan = Plan::new(4, Method::Measure(Duration::from_millis(10)));
+
+    let mut memory = GlobalPodBuffer::new(plan.fft_scratch().unwrap());
+    let stack = PodStack::new(&mut memory);
+
+    let mut buf = [c64::default(); 4];
+    plan.fwd(&mut buf, stack);
+}

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -1,0 +1,18 @@
+use wasm_bindgen_test::*;
+
+/// Running in default NodeJs Runtime.
+#[wasm_bindgen_test::wasm_bindgen_test]
+pub fn measure_n_runs_infinite_loop() {
+    use concrete_fft::c64;
+    use concrete_fft::unordered::{Method, Plan};
+    use core::time::Duration;
+    use dyn_stack::{GlobalPodBuffer, PodStack};
+
+    let plan = Plan::new(4, Method::Measure(Duration::from_millis(10)));
+
+    let mut memory = GlobalPodBuffer::new(plan.fft_scratch().unwrap());
+    let stack = PodStack::new(&mut memory);
+
+    let mut buf = [c64::default(); 4];
+    plan.fwd(&mut buf, stack);
+}


### PR DESCRIPTION
Here is the bug fix for webassembly support to `tfhe` and `concrete-fft` for server key deserialization.

To run the tests, all that is needed is to have `wasm-bindgen-cli` installed and run `cargo test --release --target wasm32-unknown-unknown`. This link shows how to setup ci-cd for it: https://rustwasm.github.io/wasm-bindgen/wasm-bindgen-test/continuous-integration.html

Here is a description of the changes:

 - `.cargo/config` tells cargo to use wasm-bindgen runners for the test;
 - Random number generation is not supported by default in wasm. Therefore, ignore compilation of tests that use `rug` or `rand` to avoid a panic;
 - wasm is unable to get the current time by default, so `std::time::Instant` does not compile. Implemented a custom Instant type that will use the type `Date` to retrieve the current time.
 - The precision of time retrieved by instant is in milliseconds. Because of that, had to change the verification with MIN_DURATION was changed from `<` to `<=`. Without this change, this conditional would always be false;
 - With the above changes, the tests will compile. But they will be running in an infinite loop. This is because of the function `measure_n_runs`. Currently there seems to be a bug with the optimization that causes the variable `n_runs` to be considered an irrelevant constant that can be optimized. Without this variable, the loop that calls this function will keep running infinitely. Forcing the function to be `never` inline fix this issue. Try this yourself. Comment that single `inline` instruction and run the test, the functions will go back to an infinite loop again.
 - There are two tests for the default `NodeJs` and `Browser` runtimes. This is enough to prove that the "infinite loop" exists and is fixed by these changes. But I believe you may be interested in adding or change more tests.
 
 Please let me know if there is any issue with these changes. I tested locally with the crate `tfhe`, and it is able to generate and do computations with the server key properly.