### PR TITLE
chore(ci): fix workflow results parsing

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels:
+    - m1mac

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          make bench
+          make FFT128_SUPPORT=ON bench
 
       - name: Parse results
         run: |
@@ -91,36 +91,12 @@ jobs:
 
       - name: Run benchmarks with AVX512
         run: |
-          make AVX512_SUPPORT=ON bench
+          make FFT128_SUPPORT=ON AVX512_SUPPORT=ON bench
 
       - name: Parse AVX512 results
         run: |
           python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
           --name-suffix avx512 \
-          --append-results
-
-          rm -rf target/criterion benchmarks_parameters/
-
-      - name: Run benchmarks with FFT128
-        run: |
-          make FFT128_SUPPORT=ON bench
-
-      - name: Parse FFT128 results
-        run: |
-          python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
-          --name-suffix fft128 \
-          --append-results
-
-          rm -rf target/criterion benchmarks_parameters/
-
-      - name: Run benchmarks with FFT128 + AVX512
-        run: |
-          make AVX512_SUPPORT=ON FFT128_SUPPORT=ON bench
-
-      - name: Parse FFT128 + AVX512 results
-        run: |
-          python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
-          --name-suffix fft128_avx512 \
           --append-results
 
       - name: Upload parsed results artifact

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,10 +55,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up home
-        # "Install rust" step require root user to have a HOME directory which is not set.
+      - name: Get benchmark details
         run: |
-          echo "HOME=/home/ubuntu" >> "${GITHUB_ENV}"
+          {
+            echo "BENCH_DATE=$(date --iso-8601=seconds)";
+            echo "COMMIT_DATE=$(git --no-pager show -s --format=%cd --date=iso8601-strict ${{ github.sha }})";
+            echo "COMMIT_HASH=$(git describe --tags --dirty)";
+          } >> "${GITHUB_ENV}"
 
       - name: Install build dependencies
         run: |
@@ -77,14 +80,12 @@ jobs:
 
       - name: Parse results
         run: |
-          COMMIT_DATE="$(git --no-pager show -s --format=%cd --date=iso8601-strict ${{ github.sha }})"
-          COMMIT_HASH="$(git describe --tags --dirty)"
           python3 ./ci/benchmark_parser.py target/criterion ${{ env.RESULTS_FILENAME }} \
           --database concrete_fft \
           --hardware "hpc7a.96xlarge" \
-          --project-version "${COMMIT_HASH}" \
+          --project-version "${{ env.COMMIT_HASH }}" \
           --branch ${{ github.ref_name }} \
-          --commit-date "${COMMIT_DATE}" \
+          --commit-date "${{ env.COMMIT_DATE }}" \
           --bench-date "${{ env.BENCH_DATE }}"
 
           rm -rf target/criterion benchmarks_parameters/

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -1,0 +1,27 @@
+# Lint and check CI
+name: CI Lint and Checks
+
+on:
+  pull_request:
+
+env:
+  ACTIONLINT_VERSION: 1.6.27
+
+jobs:
+  lint-check:
+    name: Lint and checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tfhe-rs
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Get actionlint
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) ${{ env.ACTIONLINT_VERSION }}
+          echo "f2ee6d561ce00fa93aab62a7791c1a0396ec7e8876b2a8f2057475816c550782  actionlint" > checksum
+          sha256sum -c checksum
+          ln -s "$(pwd)/actionlint" /usr/local/bin/
+
+      - name: Lint workflows
+        run: |
+          make lint_workflow

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,11 @@ check_nvm_installed:
 	@source ~/.nvm/nvm.sh && nvm --version > /dev/null 2>&1 || \
 	( echo "Unable to locate Node. Run 'make install_node'" && exit 1 )
 
+.PHONY: check_actionlint_installed # Check if actionlint workflow linter is installed
+check_actionlint_installed:
+	@actionlint --version > /dev/null 2>&1 || \
+	( echo "Unable to locate actionlint. Try installing it: https://github.com/rhysd/actionlint/releases" && exit 1 )
+
 .PHONY: fmt # Format rust code
 fmt: install_rs_check_toolchain
 	cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" fmt
@@ -85,6 +90,10 @@ fmt: install_rs_check_toolchain
 .PHONY: check_fmt # Check rust code format
 check_fmt: install_rs_check_toolchain
 	cargo "$(CARGO_RS_CHECK_TOOLCHAIN)" fmt --check
+
+.PHONY: lint_workflow # Run static linter on GitHub workflows
+lint_workflow: check_actionlint_installed
+	@actionlint
 
 .PHONY: clippy # Run clippy lints
 clippy: install_rs_check_toolchain

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -2,3 +2,4 @@
 region = "eu-west-1"
 image_id = "ami-0f96f17e9f652c6ab"
 instance_type = "hpc7a.96xlarge"
+user = "ubuntu"


### PR DESCRIPTION
This is done to fix benchmarks results stored in database.
Some FFT64 were referenced as FFT128 due to errors during parsing in benchmark workflow.